### PR TITLE
Makes sure that we don't get into infinite reconciliation loops

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,22 +3,25 @@ module github.com/PrefectHQ/prefect-operator
 go 1.21
 
 require (
+	github.com/go-logr/logr v1.4.1
+	github.com/imdario/mergo v0.3.6
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.34.1
 	k8s.io/api v0.29.2
 	k8s.io/apimachinery v0.29.2
 	k8s.io/client-go v0.29.2
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.17.3
 )
 
 require (
+	dario.cat/mergo v1.0.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.8.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
-	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
@@ -32,7 +35,6 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6 // indirect
 	github.com/google/uuid v1.3.0 // indirect
-	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
@@ -66,7 +68,6 @@ require (
 	k8s.io/component-base v0.29.2 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
-	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
+dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=

--- a/internal/controller/prefectserver_controller_test.go
+++ b/internal/controller/prefectserver_controller_test.go
@@ -375,6 +375,61 @@ var _ = Describe("PrefectServer controller", func() {
 				Expect(err).To(MatchError("Service already exists and is not controlled by PrefectServer prefect-on-anything"))
 			})
 		})
+
+		Context("When evaluating changes with any server", func() {
+			BeforeEach(func() {
+				name = types.NamespacedName{
+					Namespace: namespaceName,
+					Name:      "prefect-on-anything-no-changes",
+				}
+
+				prefectserver = &prefectiov1.PrefectServer{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespaceName,
+						Name:      "prefect-on-anything-no-changes",
+					},
+				}
+				Expect(k8sClient.Create(ctx, prefectserver)).To(Succeed())
+
+				controllerReconciler := &PrefectServerReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				// Reconcile once to create the server
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: name,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should not change a deployment if nothing has changed", func() {
+				before := &appsv1.Deployment{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: namespaceName,
+					Name:      "prefect-on-anything-no-changes",
+				}, before)).To(Succeed())
+
+				controllerReconciler := &PrefectServerReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: name,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				after := &appsv1.Deployment{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: namespaceName,
+					Name:      "prefect-on-anything-no-changes",
+				}, after)).To(Succeed())
+
+				Expect(after.Generation).To(Equal(before.Generation))
+				Expect(after).To(Equal(before))
+			})
+		})
 	})
 
 	Context("for ephemeral servers", func() {
@@ -557,6 +612,61 @@ var _ = Describe("PrefectServer controller", func() {
 					NamespacedName: name,
 				})
 				Expect(err).To(MatchError("Service already exists and is not controlled by PrefectServer prefect-on-ephemeral"))
+			})
+		})
+
+		Context("When evaluating changes with an ephemeral server", func() {
+			BeforeEach(func() {
+				name = types.NamespacedName{
+					Namespace: namespaceName,
+					Name:      "prefect-on-ephemeral-no-changes",
+				}
+
+				prefectserver = &prefectiov1.PrefectServer{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespaceName,
+						Name:      "prefect-on-ephemeral-no-changes",
+					},
+				}
+				Expect(k8sClient.Create(ctx, prefectserver)).To(Succeed())
+
+				controllerReconciler := &PrefectServerReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				// Reconcile once to create the server
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: name,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should not change a deployment if nothing has changed", func() {
+				before := &appsv1.Deployment{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: namespaceName,
+					Name:      "prefect-on-ephemeral-no-changes",
+				}, before)).To(Succeed())
+
+				controllerReconciler := &PrefectServerReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: name,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				after := &appsv1.Deployment{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: namespaceName,
+					Name:      "prefect-on-ephemeral-no-changes",
+				}, after)).To(Succeed())
+
+				Expect(after.Generation).To(Equal(before.Generation))
+				Expect(after).To(Equal(before))
 			})
 		})
 	})
@@ -786,6 +896,67 @@ var _ = Describe("PrefectServer controller", func() {
 					NamespacedName: name,
 				})
 				Expect(err).To(MatchError("Service already exists and is not controlled by PrefectServer prefect-on-sqlite"))
+			})
+		})
+
+		Context("When evaluating changes with a SQLite server", func() {
+			BeforeEach(func() {
+				name = types.NamespacedName{
+					Namespace: namespaceName,
+					Name:      "prefect-on-sqlite-no-changes",
+				}
+
+				prefectserver = &prefectiov1.PrefectServer{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespaceName,
+						Name:      "prefect-on-sqlite-no-changes",
+					},
+					Spec: prefectiov1.PrefectServerSpec{
+						SQLite: &prefectiov1.SQLiteConfiguration{
+							StorageClassName: "standard",
+							Size:             resource.MustParse("512Mi"),
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, prefectserver)).To(Succeed())
+
+				controllerReconciler := &PrefectServerReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				// Reconcile once to create the server
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: name,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should not change a deployment if nothing has changed", func() {
+				before := &appsv1.Deployment{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: namespaceName,
+					Name:      "prefect-on-sqlite-no-changes",
+				}, before)).To(Succeed())
+
+				controllerReconciler := &PrefectServerReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: name,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				after := &appsv1.Deployment{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: namespaceName,
+					Name:      "prefect-on-sqlite-no-changes",
+				}, after)).To(Succeed())
+
+				Expect(after.Generation).To(Equal(before.Generation))
+				Expect(after).To(Equal(before))
 			})
 		})
 	})
@@ -1177,6 +1348,70 @@ var _ = Describe("PrefectServer controller", func() {
 					NamespacedName: name,
 				})
 				Expect(err).To(MatchError("Service already exists and is not controlled by PrefectServer prefect-on-postgres"))
+			})
+		})
+
+		Context("When evaluating changes with a PostgreSQL server", func() {
+			BeforeEach(func() {
+				name = types.NamespacedName{
+					Namespace: namespaceName,
+					Name:      "prefect-on-postgres-no-changes",
+				}
+
+				prefectserver = &prefectiov1.PrefectServer{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespaceName,
+						Name:      "prefect-on-postgres-no-changes",
+					},
+					Spec: prefectiov1.PrefectServerSpec{
+						Postgres: &prefectiov1.PostgresConfiguration{
+							Host:     ptr.To("some-postgres-server"),
+							Port:     ptr.To(15432),
+							User:     ptr.To("a-prefect-user"),
+							Password: ptr.To("this-is-a-bad-idea"),
+							Database: ptr.To("some-prefect"),
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, prefectserver)).To(Succeed())
+
+				controllerReconciler := &PrefectServerReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				// Reconcile once to create the server
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: name,
+				})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should not change a deployment if nothing has changed", func() {
+				before := &appsv1.Deployment{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: namespaceName,
+					Name:      "prefect-on-postgres-no-changes",
+				}, before)).To(Succeed())
+
+				controllerReconciler := &PrefectServerReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: name,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				after := &appsv1.Deployment{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: namespaceName,
+					Name:      "prefect-on-postgres-no-changes",
+				}, after)).To(Succeed())
+
+				Expect(after.Generation).To(Equal(before.Generation))
+				Expect(after).To(Equal(before))
 			})
 		})
 	})


### PR DESCRIPTION
It's important to difference the cluster state against the desired state in
order to not continually update, say, a Deployment on a tight loop.  This
requires some diffing logic, which I'm doing here with `mergo` to merge the
desired state onto the current state to see if it changes.
