### PR TITLE
Give controller access to manipulate PVCs

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -26,6 +26,18 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/internal/controller/prefectserver_controller.go
+++ b/internal/controller/prefectserver_controller.go
@@ -50,6 +50,7 @@ type PrefectServerReconciler struct {
 //+kubebuilder:rbac:groups=prefect.io,resources=prefectservers/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=prefect.io,resources=prefectservers/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch


### PR DESCRIPTION
## Summary

Currently, the Controller will start up and eventually crash because it can't watch PVCs. This gives it the correct permission to manipulate those objects.

## Testing

Start the controller with these changes and observe the log entry:

```
manager 2024-08-20T21:23:56Z    INFO    Starting EventSource    {"controller": "prefectserver", "controllerGroup": "prefect.io", "controllerKind": "PrefectServer", "source": "kind source: *v1.PersistentVolumeClaim"}
```

Confirm that it doesn't crash after 1-2 minutes.