### PR TITLE
Restores CRD descriptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	# Note that the option maxDescLen=0 was added in the default scaffold in order to sort out the issue
-	# Too long: must have at most 262144 bytes. By using kubectl apply to create / update resources an annotation
-	# is created by K8s API to store the latest version of the resource ( kubectl.kubernetes.io/last-applied-configuration).
-	# However, it has a size limit and if the CRD is too big with so many long descriptions as this one it will cause the failure.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd:maxDescLen=0 webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
 generate: tools ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.


### PR DESCRIPTION
In our [previous change to de-scaffold the extra operator-sdk boilerplate](https://github.com/PrefectHQ/prefect-operator/pull/47), we
lost the descriptions in our CRDs.  Since we're not experiencing the issue
described in the comment, we can keep our descriptions for now to help with
documentation.
