### PR TITLE
Adds `Ready` status boolean for `PrefectServer` and `PrefectWorkPool`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	# Note that the option maxDescLen=0 was added in the default scaffold in order to sort out the issue
-	# Too long: must have at most 262144 bytes. By using kubectl apply to create / update resources an annotation
-	# is created by K8s API to store the latest version of the resource ( kubectl.kubernetes.io/last-applied-configuration).
-	# However, it has a size limit and if the CRD is too big with so many long descriptions as this one it will cause the failure.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd:maxDescLen=0 webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
 generate: tools ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/api/v1/prefectserver_types.go
+++ b/api/v1/prefectserver_types.go
@@ -196,8 +196,11 @@ func (p *PostgresConfiguration) DatabaseEnvVar() corev1.EnvVar {
 
 // PrefectServerStatus defines the observed state of PrefectServer
 type PrefectServerStatus struct {
-	// Version is the version of the Prefect Server that is currently running
+	// Version is the version of the PrefectServer that is currently running
 	Version string `json:"version"`
+
+	// Ready indicates that the PrefectServer is ready to serve requests
+	Ready bool `json:"ready"`
 
 	// Conditions store the status conditions of the PrefectServer instances
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
@@ -206,6 +209,7 @@ type PrefectServerStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version",description="The version of this Prefect server"
+// +kubebuilder:printcolumn:name="Ready",type="boolean",JSONPath=".status.ready",description="Whether this Prefect server is ready to receive requests"
 // PrefectServer is the Schema for the prefectservers API
 type PrefectServer struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1/prefectworkpool_types.go
+++ b/api/v1/prefectworkpool_types.go
@@ -63,6 +63,9 @@ type PrefectWorkPoolStatus struct {
 	// ReadyWorkers is the number of workers that are currently ready
 	ReadyWorkers int32 `json:"readyWorkers"`
 
+	// Ready is true if the work pool is ready to accept work
+	Ready bool `json:"ready"`
+
 	// Conditions store the status conditions of the PrefectWorkPool instances
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 }
@@ -71,6 +74,7 @@ type PrefectWorkPoolStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type",description="The type of this work pool"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version",description="The version of this work pool"
+// +kubebuilder:printcolumn:name="Ready",type="boolean",JSONPath=".status.ready",description="Whether the work pool is ready"
 // +kubebuilder:printcolumn:name="Desired Workers",type="integer",JSONPath=".spec.workers",description="How many workers are desired"
 // +kubebuilder:printcolumn:name="Ready Workers",type="integer",JSONPath=".status.readyWorkers",description="How many workers are ready"
 // PrefectWorkPool is the Schema for the prefectworkpools API

--- a/config/crd/bases/prefect.io_prefectservers.yaml
+++ b/config/crd/bases/prefect.io_prefectservers.yaml
@@ -19,6 +19,10 @@ spec:
       jsonPath: .status.version
       name: Version
       type: string
+    - description: Whether this Prefect server is ready to receive requests
+      jsonPath: .status.ready
+      name: Ready
+      type: boolean
     name: v1
     schema:
       openAPIV3Schema:
@@ -768,11 +772,16 @@ spec:
                   - type
                   type: object
                 type: array
+              ready:
+                description: Ready indicates that the PrefectServer is ready to serve
+                  requests
+                type: boolean
               version:
-                description: Version is the version of the Prefect Server that is
-                  currently running
+                description: Version is the version of the PrefectServer that is currently
+                  running
                 type: string
             required:
+            - ready
             - version
             type: object
         type: object

--- a/config/crd/bases/prefect.io_prefectworkpools.yaml
+++ b/config/crd/bases/prefect.io_prefectworkpools.yaml
@@ -23,6 +23,10 @@ spec:
       jsonPath: .status.version
       name: Version
       type: string
+    - description: Whether the work pool is ready
+      jsonPath: .status.ready
+      name: Ready
+      type: boolean
     - description: How many workers are desired
       jsonPath: .spec.workers
       name: Desired Workers
@@ -328,6 +332,9 @@ spec:
                   - type
                   type: object
                 type: array
+              ready:
+                description: Ready is true if the work pool is ready to accept work
+                type: boolean
               readyWorkers:
                 description: ReadyWorkers is the number of workers that are currently
                   ready
@@ -338,6 +345,7 @@ spec:
                   currently running
                 type: string
             required:
+            - ready
             - readyWorkers
             - version
             type: object

--- a/internal/conditions/conditions.go
+++ b/internal/conditions/conditions.go
@@ -6,82 +6,73 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func newCondition(typeVal, reason, message string, status metav1.ConditionStatus) metav1.Condition {
+func NotRequired(object string) metav1.Condition {
 	return metav1.Condition{
-		Type:    typeVal,
-		Status:  status,
-		Reason:  reason,
-		Message: message,
+		Type:    fmt.Sprintf("%sReconciled", object),
+		Reason:  fmt.Sprintf("%sNotRequired", object),
+		Message: fmt.Sprintf("%s is not required", object),
+		Status:  metav1.ConditionTrue,
 	}
 }
 
-func NotRequired(object string) metav1.Condition {
-	return newCondition(
-		fmt.Sprintf("%sReconciled", object),
-		fmt.Sprintf("%sNotRequired", object),
-		fmt.Sprintf("%s is not required", object),
-		metav1.ConditionTrue,
-	)
-}
-
 func NotCreated(object string, err error) metav1.Condition {
-	return newCondition(
-		fmt.Sprintf("%sReconciled", object),
-		fmt.Sprintf("%sNotCreated", object),
-		fmt.Sprintf("%s was not created: %v", object, err.Error()),
-		metav1.ConditionFalse,
-	)
+	return metav1.Condition{
+		Type:    fmt.Sprintf("%sReconciled", object),
+		Reason:  fmt.Sprintf("%sNotCreated", object),
+		Message: fmt.Sprintf("%s was not created: %v", object, err.Error()),
+		Status:  metav1.ConditionFalse,
+	}
 }
 
 func Created(object string) metav1.Condition {
-	return newCondition(
-		fmt.Sprintf("%sReconciled", object),
-		fmt.Sprintf("%sCreated", object),
-		fmt.Sprintf("%s was created", object),
-		metav1.ConditionTrue,
-	)
+	return metav1.Condition{
+		Type:    fmt.Sprintf("%sReconciled", object),
+		Reason:  fmt.Sprintf("%sCreated", object),
+		Message: fmt.Sprintf("%s was created", object),
+		Status:  metav1.ConditionTrue,
+	}
 }
 
 func UnknownError(object string, err error) metav1.Condition {
-	return newCondition(
-		fmt.Sprintf("%sReconciled", object),
-		"UnknownError",
-		"Unknown error: "+err.Error(),
-		metav1.ConditionFalse,
-	)
+	return metav1.Condition{
+		Type:    fmt.Sprintf("%sReconciled", object),
+		Reason:  "UnknownError",
+		Message: "Unknown error: " + err.Error(),
+		Status:  metav1.ConditionFalse,
+	}
 }
 
 func AlreadyExists(object string, message string) metav1.Condition {
-	return newCondition(
-		fmt.Sprintf("%sReconciled", object),
-		fmt.Sprintf("%sAlreadyExists", object),
-		message,
-		metav1.ConditionFalse,
-	)
+	return metav1.Condition{
+		Type:    fmt.Sprintf("%sReconciled", object),
+		Reason:  fmt.Sprintf("%sAlreadyExists", object),
+		Message: message,
+		Status:  metav1.ConditionFalse,
+	}
 }
 func Updated(object string) metav1.Condition {
-	return newCondition(
-		fmt.Sprintf("%sReconciled", object),
-		fmt.Sprintf("%sUpdated", object),
-		fmt.Sprintf("%s is in the correct state", object),
-		metav1.ConditionTrue,
-	)
+	return metav1.Condition{
+		Type:    fmt.Sprintf("%sReconciled", object),
+		Reason:  fmt.Sprintf("%sUpdated", object),
+		Message: fmt.Sprintf("%s is in the correct state", object),
+		Status:  metav1.ConditionTrue,
+	}
 }
 
 func NeedsUpdate(object string) metav1.Condition {
-	return newCondition(
-		fmt.Sprintf("%sReconciled", object),
-		fmt.Sprintf("%sNeedsUpdate", object),
-		fmt.Sprintf("%s needs to be updated", object),
-		metav1.ConditionFalse,
-	)
+	return metav1.Condition{
+		Type:    fmt.Sprintf("%sReconciled", object),
+		Reason:  fmt.Sprintf("%sNeedsUpdate", object),
+		Message: fmt.Sprintf("%s needs to be updated", object),
+		Status:  metav1.ConditionFalse,
+	}
 }
 
 func UpdateFailed(object string, err error) metav1.Condition {
-	return newCondition(
-		fmt.Sprintf("%sReconciled", object),
-		fmt.Sprintf("%sUpdateFailed", object),
-		fmt.Sprintf("%s update failed: %v", object, err.Error()),
-		metav1.ConditionFalse,
-	)
+	return metav1.Condition{
+		Type:    fmt.Sprintf("%sReconciled", object),
+		Reason:  fmt.Sprintf("%sUpdateFailed", object),
+		Message: fmt.Sprintf("%s update failed: %v", object, err.Error()),
+		Status:  metav1.ConditionFalse,
+	}
 }

--- a/internal/controller/prefectserver_controller.go
+++ b/internal/controller/prefectserver_controller.go
@@ -271,7 +271,7 @@ func (r *PrefectServerReconciler) reconcileDeployment(ctx context.Context, serve
 			condition = conditions.Updated(objName)
 		}
 
-		ready := foundDeployment.Status.AvailableReplicas > 0
+		ready := foundDeployment.Status.ReadyReplicas > 0
 		version := prefectiov1.VersionFromImage(desiredDeployment.Spec.Template.Spec.Containers[0].Image)
 
 		if server.Status.Ready != ready || server.Status.Version != version {

--- a/internal/controller/prefectserver_controller_test.go
+++ b/internal/controller/prefectserver_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -1642,6 +1643,116 @@ var _ = Describe("PrefectServer controller", func() {
 				Expect(after.Generation).To(Equal(before.Generation))
 				Expect(after).To(Equal(before))
 			})
+		})
+	})
+
+	Context("PrefectServer Status Updates", func() {
+		var (
+			prefectServer *prefectiov1.PrefectServer
+			deployment    *appsv1.Deployment
+			reconciler    *PrefectServerReconciler
+			name          types.NamespacedName
+		)
+
+		BeforeEach(func() {
+			name = types.NamespacedName{
+				Namespace: "test-" + uuid.New().String(),
+				Name:      "test-prefectserver",
+			}
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name.Namespace}}
+			Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+
+			prefectServer = &prefectiov1.PrefectServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name.Name,
+					Namespace: name.Namespace,
+				},
+				Spec: prefectiov1.PrefectServerSpec{},
+			}
+			Expect(k8sClient.Create(ctx, prefectServer)).To(Succeed())
+
+			reconciler = &PrefectServerReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: name,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			deployment = &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, name, deployment)).To(Succeed())
+
+			// Update the replicas to 1, which the Deployment controller would do
+			deployment.Status.Replicas = 1
+			Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+		})
+
+		It("should have default values initially", func() {
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			updatedPrefectServer := &prefectiov1.PrefectServer{}
+			Expect(k8sClient.Get(ctx, name, updatedPrefectServer)).To(Succeed())
+			Expect(updatedPrefectServer.Status.Ready).To(Equal(false))
+		})
+
+		It("should update status when becoming ready", func() {
+			deployment.Status.ReadyReplicas = 1
+			Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			updatedPrefectServer := &prefectiov1.PrefectServer{}
+			Expect(k8sClient.Get(ctx, name, updatedPrefectServer)).To(Succeed())
+			Expect(updatedPrefectServer.Status.Ready).To(Equal(true))
+		})
+
+		It("should update status when becoming unready", func() {
+			deployment.Status.ReadyReplicas = 0
+			Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			updatedPrefectServer := &prefectiov1.PrefectServer{}
+			Expect(k8sClient.Get(ctx, name, updatedPrefectServer)).To(Succeed())
+			Expect(updatedPrefectServer.Status.Ready).To(Equal(false))
+		})
+
+		It("should toggle status correctly", func() {
+			// First, make it ready
+			deployment.Status.ReadyReplicas = 1
+			Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+
+			updatedPrefectServer := &prefectiov1.PrefectServer{}
+			Expect(k8sClient.Get(ctx, name, updatedPrefectServer)).To(Succeed())
+			Expect(updatedPrefectServer.Status.Ready).To(Equal(true))
+
+			// Then, make it unready
+			deployment.Status.ReadyReplicas = 0
+			Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, name, updatedPrefectServer)).To(Succeed())
+			Expect(updatedPrefectServer.Status.Ready).To(Equal(false))
+
+			// Finally, make it ready again
+			deployment.Status.ReadyReplicas = 1
+			Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, name, updatedPrefectServer)).To(Succeed())
+			Expect(updatedPrefectServer.Status.Ready).To(Equal(true))
 		})
 	})
 })


### PR DESCRIPTION
For both of these, `Ready` will be true when there is at least one ready
replica of the underlying deployment.  While working on this, I also noticed
that we were _always_ attempting to add a condition, even if nothing had
changed (and thus the condition struct was empty), which would lead to quiet
errors with all further reconciliations.  Now we'll exit early if the condition
isn't populated, report errors if we can't update the status, and explicitly
update the status when non-conditions are changed.

Fixes #49
