### PR TITLE
Adds `Worker` healthchecks

### DIFF
--- a/internal/controller/prefectserver_controller_test.go
+++ b/internal/controller/prefectserver_controller_test.go
@@ -308,6 +308,56 @@ var _ = Describe("PrefectServer controller", func() {
 						corev1.ResourceMemory: resource.MustParse("512Mi"),
 					}))
 				})
+
+				It("should have the correct startup, readiness, and liveness probes", func() {
+					Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+					container := deployment.Spec.Template.Spec.Containers[0]
+
+					Expect(container.StartupProbe).To(Equal(&corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/api/health",
+								Port:   intstr.FromInt(4200),
+								Scheme: corev1.URISchemeHTTP,
+							},
+						},
+						InitialDelaySeconds: 10,
+						PeriodSeconds:       5,
+						TimeoutSeconds:      5,
+						SuccessThreshold:    1,
+						FailureThreshold:    30,
+					}))
+
+					Expect(container.ReadinessProbe).To(Equal(&corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/api/health",
+								Port:   intstr.FromInt(4200),
+								Scheme: corev1.URISchemeHTTP,
+							},
+						},
+						InitialDelaySeconds: 10,
+						PeriodSeconds:       5,
+						TimeoutSeconds:      5,
+						SuccessThreshold:    1,
+						FailureThreshold:    30,
+					}))
+
+					Expect(container.LivenessProbe).To(Equal(&corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/api/health",
+								Port:   intstr.FromInt(4200),
+								Scheme: corev1.URISchemeHTTP,
+							},
+						},
+						InitialDelaySeconds: 120,
+						PeriodSeconds:       10,
+						TimeoutSeconds:      5,
+						SuccessThreshold:    1,
+						FailureThreshold:    2,
+					}))
+				})
 			})
 
 			Describe("the Service", func() {

--- a/internal/controller/prefectworkpool_controller.go
+++ b/internal/controller/prefectworkpool_controller.go
@@ -194,9 +194,9 @@ func (r *PrefectWorkPoolReconciler) prefectWorkerDeployment(workPool *prefectiov
 
 							Resources: workPool.Spec.Resources,
 
-							// StartupProbe:   workPool.StartupProbe(),
-							// ReadinessProbe: workPool.ReadinessProbe(),
-							// LivenessProbe:  workPool.LivenessProbe(),
+							StartupProbe:   workPool.StartupProbe(),
+							ReadinessProbe: workPool.ReadinessProbe(),
+							LivenessProbe:  workPool.LivenessProbe(),
 
 							TerminationMessagePath:   "/dev/termination-log",
 							TerminationMessagePolicy: corev1.TerminationMessageReadFile,


### PR DESCRIPTION
Prefect's `Worker` supports a `--with-healthcheck` option, with a configurable
port for serving a small health probe API.  This change adds the health check
option and startup/readiness/liveness probes to the `Deployment` managed by the
`PrefectWorkPool`

Fixes #52
