### PR TITLE
Fix Docker image name for prod environment

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,7 +83,7 @@ jobs:
         id: metadata
         uses: docker/metadata-action@v5
         with:
-          images: prefecthq/prefect-operator${{ github.event_name == 'pull_request' && '-dev' }}
+          images: prefecthq/prefect-operator${{ github.event_name == 'pull_request' && '-dev' || '' }}
           tags: |
             type=ref,event=pr
             type=ref,event=branch


### PR DESCRIPTION
Looks like GitHub's evaluation logic will return 'false' if the condition doesn't match, so let's specifically apply an empty string instead.

Should address [this CI error](https://github.com/PrefectHQ/prefect-operator/actions/runs/10729267023/job/29755566240#step:6:383).