### PR TITLE
Fix production docker image name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,12 +83,9 @@ jobs:
         id: metadata
         uses: docker/metadata-action@v5
         with:
-          # When running jobs for a tag, do not apply an image name suffix to
-          # push to the production repository.
-          #
-          # In other situations, such as pull requests and main, add a '-dev'
-          # image name suffix to push to the dev repository.
-          images: prefecthq/prefect-operator${{ github.ref_type == 'tag' && '' || '-dev' }}
+          # For jobs on tags, push to the prod repository.
+          # For all other situations, like pull requests and 'main', push to the dev repository.
+          images: prefecthq/${{ github.ref_type == 'tag' && 'prefect-operator' || 'prefect-operator-dev' }}
           tags: |
             type=ref,event=pr
             type=ref,event=branch


### PR DESCRIPTION
Returning '' is considered null in GitHub's action evaluation, which was causing it to always return the '-dev'-suffixed image name.

This revamps the image name calculation so it returns a valid string in both cases.

Related to https://github.com/PrefectHQ/prefect-operator/issues/66