### PR TITLE
chore: disable `kube rbac proxy` by default for now

### DIFF
--- a/deploy/charts/prefect-operator/README.md
+++ b/deploy/charts/prefect-operator/README.md
@@ -86,7 +86,7 @@ tbd
 | commonAnnotations | object | `{}` | annotations to add to all deployed objects |
 | commonLabels | object | `{"app.kubernetes.io/component":"operator"}` | labels to add to all deployed objects |
 | fullnameOverride | string | `"prefect-operator"` | fully override common.names.fullname |
-| kubeRbacProxy.create | bool | `true` | specifies whether the kube-rbac-proxy should be deployed to the cluster |
+| kubeRbacProxy.create | bool | `false` | specifies whether the kube-rbac-proxy should be deployed to the cluster |
 | kubeRbacProxy.image | string | `"gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0"` | the image of the kube-rbac-proxy to use |
 | kubeRbacProxy.name | string | `"kube-rbac-proxy"` | the name of the kube-rbac-proxy to use |
 | metrics.enabled | bool | `false` | enable the export of Prometheus metrics |

--- a/deploy/charts/prefect-operator/values.yaml
+++ b/deploy/charts/prefect-operator/values.yaml
@@ -173,7 +173,7 @@ serviceAccount:
 ## ref: https://github.com/brancz/kube-rbac-proxy
 kubeRbacProxy:
   # -- specifies whether the kube-rbac-proxy should be deployed to the cluster
-  create: true
+  create: false
   # -- the name of the kube-rbac-proxy to use
   name: kube-rbac-proxy
   # -- the image of the kube-rbac-proxy to use
@@ -185,7 +185,7 @@ kubeRbacProxy:
 metrics:
   # -- enable the export of Prometheus metrics
   enabled: false
-#   ## Prometheus Operator ServiceMonitor configuration
+  ## Prometheus Operator ServiceMonitor configuration
   serviceMonitor:
     # -- creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
     enabled: false


### PR DESCRIPTION
This was part of the original scaffolding we leveraged -- we don't know if we want this yet, so let's disable by default.

Relates to PLA-300