### PR TITLE
Bump golangci-lint version

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,7 +2,7 @@
 actionlint = '1.7.1'
 ginkgo = '2.19.0'
 golang = '1.21'
-golangci-lint = '1.57.2'
+golangci-lint = '1.61.0'
 helm = '3.15'
 helm-ct = '3.11.0'
 helm-docs = '1.13.1'


### PR DESCRIPTION
Bumps golangci-lint to address performance problems that were bringing my machine to a halt.

Related to https://linear.app/prefect/issue/PLA-289/cycle-2-catch-all