### PR TITLE
Package all manifests with release

### DIFF
--- a/.github/workflows/helm-unittest.yaml
+++ b/.github/workflows/helm-unittest.yaml
@@ -3,7 +3,12 @@
 
 name: Run Helm unit tests
 
-"on": pull_request
+"on":
+  pull_request:
+    branches:
+      - main
+    paths:
+      - deploy/charts/**
 
 # Do not grant jobs any permissions by default
 permissions: {}

--- a/.github/workflows/operator-lint-and-test.yaml
+++ b/.github/workflows/operator-lint-and-test.yaml
@@ -2,6 +2,10 @@ name: Lint and Test Prefect Operator Chart
 
 "on":
   pull_request:
+    branches:
+      - main
+    paths:
+      - deploy/charts/**
 
 # Do not grant jobs any permissions by default
 permissions: {}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,9 +49,7 @@ jobs:
         run: |
           # package just CRDs
           cat deploy/charts/prefect-operator/crds/*.yaml > prefect-crds.yaml
-          # handle helm dependencies
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm dependency build deploy/charts/prefect-operator
+          make helmbuild
           # template the helm chart including the CRDs
           helm template prefect-operator deploy/charts/prefect-operator \
           --include-crds --set operator.image.tag=${{ github.ref_name }} \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,7 +61,7 @@ jobs:
         if: github.ref_type == 'tag'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.ref_name }} prefect-crds.yaml
+        run: gh release upload ${{ github.ref_name }} prefect-crds.yaml prefect-operator.yaml
 
   build-and-push-docker-image:
     needs: unit-tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,7 @@ jobs:
       - name: Package kubernetes manifests & CRDs
         run: |
           cat deploy/charts/prefect-operator/crds/*.yaml > prefect-crds.yaml
+          helm repo add bitnami https://charts.bitnami.com/bitnami
           helm dependency build deploy/charts/prefect-operator
           helm template prefect-operator deploy/charts/prefect-operator \
           --include-crds --set operator.image.tag=${{ github.ref_name }} \
@@ -56,8 +57,7 @@ jobs:
           yq -i 'del(.metadata.labels."helm.sh/chart")' prefect-operator.yaml
           yq -i 'del(.spec.template.metadata.labels."app.kubernetes.io/managed-by")' prefect-operator.yaml
           yq -i 'del(.spec.template.metadata.labels."helm.sh/chart")' prefect-operator.yaml
-          yq -i '.metadata.labels."app.kubernetes.io/version" = "${{ github.ref_name }}"' prefect-operator.yaml
-          yq -i '.spec.template.metadata.labels."app.kubernetes.io/version" = "${{ github.ref_name }}"' prefect-operator.yaml
+          yq -i '(.. | select(tag == "!!str" and . == "v0.0.0")) |= "${{ github.ref_name }}0"' prefect-operator.yaml
 
       - name: Upload release assets
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,8 @@ jobs:
           yq -i 'del(.metadata.labels."helm.sh/chart")' prefect-operator.yaml
           yq -i 'del(.spec.template.metadata.labels."app.kubernetes.io/managed-by")' prefect-operator.yaml
           yq -i 'del(.spec.template.metadata.labels."helm.sh/chart")' prefect-operator.yaml
-          yq -i '.metadata.labels."app.kubernetes.io/version" = ${{ github.ref_name }}"' prefect-operator.yaml
+          yq -i '.metadata.labels."app.kubernetes.io/version" = "${{ github.ref_name }}"' prefect-operator.yaml
+          yq -i '.spec.template.metadata.labels."app.kubernetes.io/version" = "${{ github.ref_name }}"' prefect-operator.yaml
 
       - name: Upload release assets
         if: github.ref_type == 'tag'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,7 @@ jobs:
         uses: jdx/mise-action@v2
 
       - name: Package kubernetes manifests & CRDs
+        if: github.ref_type == 'tag'
         run: |
           cat deploy/charts/prefect-operator/crds/*.yaml > prefect-crds.yaml
           helm dependency build deploy/charts/prefect-operator

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,17 +47,22 @@ jobs:
 
       - name: Package kubernetes manifests & CRDs
         run: |
+          # package just CRDs
           cat deploy/charts/prefect-operator/crds/*.yaml > prefect-crds.yaml
+          # handle helm dependencies
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm dependency build deploy/charts/prefect-operator
+          # template the helm chart including the CRDs
           helm template prefect-operator deploy/charts/prefect-operator \
           --include-crds --set operator.image.tag=${{ github.ref_name }} \
           > prefect-operator.yaml
+          # Remove labels relevant only for Helm installs
           yq -i 'del(.metadata.labels."app.kubernetes.io/managed-by")' prefect-operator.yaml
           yq -i 'del(.metadata.labels."helm.sh/chart")' prefect-operator.yaml
           yq -i 'del(.spec.template.metadata.labels."app.kubernetes.io/managed-by")' prefect-operator.yaml
           yq -i 'del(.spec.template.metadata.labels."helm.sh/chart")' prefect-operator.yaml
-          yq -i '(.. | select(tag == "!!str" and . == "v0.0.0")) |= "${{ github.ref_name }}0"' prefect-operator.yaml
+          # Ensure all references to app version match the released version tag
+          yq -i '(.. | select(tag == "!!str" and . == "v0.0.0")) |= "${{ github.ref_name }}"' prefect-operator.yaml
 
       - name: Upload release assets
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,7 @@ jobs:
         run: make test
 
   build-and-upload-manifests:
+    if: github.ref_type == 'tag'
     needs: unit-tests
     permissions:
       contents: write
@@ -45,7 +46,6 @@ jobs:
         uses: jdx/mise-action@v2
 
       - name: Package kubernetes manifests & CRDs
-        if: github.ref_type == 'tag'
         run: |
           cat deploy/charts/prefect-operator/crds/*.yaml > prefect-crds.yaml
           helm dependency build deploy/charts/prefect-operator
@@ -60,7 +60,6 @@ jobs:
           yq -i '.spec.template.metadata.labels."app.kubernetes.io/version" = "${{ github.ref_name }}"' prefect-operator.yaml
 
       - name: Upload release assets
-        if: github.ref_type == 'tag'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ github.ref_name }} prefect-crds.yaml prefect-operator.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,14 @@ jobs:
       - name: Package CRDs
         run: |
           cat deploy/charts/prefect-operator/crds/*.yaml > prefect-crds.yaml
+          helm template prefect-operator deploy/charts/prefect-operator \
+          --include-crds --set operator.image.tag=${{ github.ref_name }} \
+          > prefect-operator.yaml
+          yq -i 'del(.metadata.labels."app.kubernetes.io/managed-by")' prefect-operator.yaml
+          yq -i 'del(.metadata.labels."helm.sh/chart")' prefect-operator.yaml
+          yq -i 'del(.spec.template.metadata.labels."app.kubernetes.io/managed-by")' prefect-operator.yaml
+          yq -i 'del(.spec.template.metadata.labels."helm.sh/chart")' prefect-operator.yaml
+          yq -i '.metadata.labels."app.kubernetes.io/version" = ${{ github.ref_name }}"' prefect-operator.yaml
 
       - name: Upload release assets
         if: github.ref_type == 'tag'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,9 +44,10 @@ jobs:
       - name: Install tool dependencies
         uses: jdx/mise-action@v2
 
-      - name: Package CRDs
+      - name: Package kubernetes manifests & CRDs
         run: |
           cat deploy/charts/prefect-operator/crds/*.yaml > prefect-crds.yaml
+          helm dependency build deploy/charts/prefect-operator
           helm template prefect-operator deploy/charts/prefect-operator \
           --include-crds --set operator.image.tag=${{ github.ref_name }} \
           > prefect-operator.yaml

--- a/.mise.toml
+++ b/.mise.toml
@@ -12,6 +12,7 @@ kustomize = '5.3.0'
 pre-commit = '3.8.0'
 setup-envtest = '0.17.0'
 yamllint = '1.35.1'
+yq = '4.44.3'
 
 # tomlv does not currently have an entry in the registry.
 # For now, install with `go`:

--- a/.yamllint
+++ b/.yamllint
@@ -2,7 +2,7 @@
 extends: default
 
 ignore: |
-  deploy/
+  deploy/charts/
 
 rules:
   comments:

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ vet: ## Run go vet against code.
 
 .PHONY: helmbuild
 helmbuild: ## Build Helm dependencies
+	helm repo add bitnami https://charts.bitnami.com/bitnami
 	helm dependency build $(CHART_PATH)
 
 

--- a/deploy/samples/kustomization.yaml
+++ b/deploy/samples/kustomization.yaml
@@ -1,4 +1,3 @@
-## Append samples of your project ##
 resources:
   - v1_prefectserver_sqlite.yaml
   - v1_prefectworkpool_process.yaml
@@ -7,4 +6,3 @@ resources:
   # - v1_prefectserver_sqlite.yaml
   # - v1_prefectworkpool_kubernetes.yaml
   # - v1_prefectworkpool_process.yaml
-#+kubebuilder:scaffold:manifestskustomizesamples

--- a/deploy/samples/v1_prefectworkpool_external_prefect_cloud.yaml
+++ b/deploy/samples/v1_prefectworkpool_external_prefect_cloud.yaml
@@ -4,7 +4,7 @@ metadata:
   name: the-api-key-secret
 type: Opaque
 stringData:
-  the-api-key: "pnu_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+  the-api-key: pnu_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ---
 apiVersion: prefect.io/v1
 kind: PrefectWorkPool
@@ -17,11 +17,11 @@ spec:
   type: process
   server:
     remoteApiUrl: https://api.prefect.cloud
-    accountId:   aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+    accountId: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
     workspaceId: bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
     apiKey:
       valueFrom:
         secretKeyRef:
-          name: 'the-api-key-secret'
-          key: 'the-api-key'
+          name: the-api-key-secret
+          key: the-api-key
   workers: 3


### PR DESCRIPTION
This PR adds logic to template the helm charts into plain kubernetes manifests. We utilize `yq` to remove references to `helm` & update the version referenced across all manifests to match the app version being released.

Also updates `helm-unittest` and `operator-lint-and-test` workflows to only run on PRs against main & when the relevant directory has changes

Closes PLA-334