### PR TITLE
Stop linting toml

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -31,7 +31,6 @@ jobs:
 
       - name: Install tool dependencies (non-mise)
         run: |
-          go install github.com/BurntSushi/toml/cmd/tomlv@latest
           go install golang.org/x/tools/cmd/goimports@latest
 
       - name: Build helm dependencies

--- a/.mise.toml
+++ b/.mise.toml
@@ -12,7 +12,3 @@ kustomize = '5.3.0'
 pre-commit = '3.8.0'
 setup-envtest = '0.17.0'
 yamllint = '1.35.1'
-
-# tomlv does not currently have an entry in the registry.
-# For now, install with `go`:
-# go install github.com/BurntSushi/toml/cmd/tomlv@latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,6 @@ repos:
       # See https://github.com/dnephin/pre-commit-golang/issues/30
       # - id: go-vet
       - id: go-imports
-      - id: validate-toml
       - id: golangci-lint
       # We already run unit tests in tests.yaml, which ensures
       # they're called properly by using the `make` target.


### PR DESCRIPTION
We don't use any TOML in this project, so let's disable the linter and stop installing related tools.

This likely just came in from a copy/pasta of our other pre-commit configs when setting this up.

Related to https://linear.app/prefect/issue/PLA-289/cycle-2-catch-all