### PR TITLE
Automate Helm Chart release following prefect-cloud-operator release

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -2,7 +2,8 @@
 name: prefect-operator Helm Chart release
 
 "on":
-  workflow_dispatch:
+  workflow_dispatch: {}
+  workflow_call: {}
 
 permissions: {}
 

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Create Github Release + Tag
         run: |
-          gh release create "${RELEASE_VERSION}" \
+          gh release create -t "${RELEASE_VERSION}" \
             --latest=false \
             --notes "Packaged with prefect-operator version \
             [${OPERATOR_VERSION}](https://github.com/PrefectHQ/prefect-operator/releases/tag/${OPERATOR_VERSION})"

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,5 +1,5 @@
 ---
-name: prefect-operator Helm Chart release
+name: Release Prefect Operator Helm Chart
 
 "on":
   workflow_dispatch: {}

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -6,7 +6,7 @@ name: Labeler
       - opened
 
 jobs:
-  apply-label:
+  apply_label:
     runs-on: ubuntu-latest
     steps:
       - name: Apply prefect-operator label to all issues

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ name: Release Prefect Operator
 permissions: {}
 
 jobs:
-  unit-tests:
+  unit_tests:
     name: Unit tests
     runs-on: ubuntu-latest
     permissions:
@@ -34,7 +34,7 @@ jobs:
 
   build_and_upload_manifests:
     if: github.ref_type == 'tag'
-    needs: unit-tests
+    needs: unit_tests
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -68,7 +68,7 @@ jobs:
         run: gh release upload ${{ github.ref_name }} prefect-crds.yaml prefect-operator.yaml
 
   build_and_push_docker_image:
-    needs: unit-tests
+    needs: unit_tests
     runs-on: ubuntu-latest
     # The GitHub environments are created by Terraform and map to Docker Hub repositories:
     # - dev: https://hub.docker.com/r/prefecthq/prefect-operator-dev

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,3 +120,4 @@ jobs:
     needs: build_and_push_docker_image
     if: github.ref_type == 'tag'
     uses: ./.github/workflows/helm-release.yaml
+    secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,5 @@
 ---
-name: prefect-operator release
+name: Release Prefect Operator
 
 "on":
   push:
@@ -32,7 +32,7 @@ jobs:
       - name: Test
         run: make test
 
-  build-and-upload-manifests:
+  build_and_upload_manifests:
     if: github.ref_type == 'tag'
     needs: unit-tests
     permissions:
@@ -67,7 +67,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ github.ref_name }} prefect-crds.yaml prefect-operator.yaml
 
-  build-and-push-docker-image:
+  build_and_push_docker_image:
     needs: unit-tests
     runs-on: ubuntu-latest
     # The GitHub environments are created by Terraform and map to Docker Hub repositories:
@@ -113,3 +113,10 @@ jobs:
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
+
+  release_helm_chart:
+    permissions:
+      contents: write
+    needs: build_and_push_docker_image
+    if: github.ref_type == 'tag'
+    uses: ./.github/workflows/helm-release.yaml

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  pre-commit-checks:
+  pre_commit_checks:
     name: pre-commit checks
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Also renames some workflows to leverage underscores rather than dashes in yaml

Relates PLA-332