### PR TITLE
fix/Fix the output of the image version

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -33,7 +33,7 @@ jobs:
           # This ensures that the latest tag we grab will be of the operator image, and not the helm chart
           echo "IMAGE_VERSION=$(\
           git ls-remote --tags --refs --sort="v:refname" \
-          origin 'v[0-9].[0-9].[0-9]' | tail -n1 | sed 's/.*\///')" | sed 's/v//' >> $GITHUB_OUTPUT
+          origin 'v[0-9].[0-9].[0-9]' | tail -n1 | sed 's/.*\///' | sed 's/v//')" >> $GITHUB_OUTPUT
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
Relates to PLA-289

Image version was not properly being saved to the Github output and this should fix. 

![Screenshot 2024-09-23 at 10 29 43 AM](https://github.com/user-attachments/assets/d1f8368b-1a2d-4be6-83cb-713a62a2b173)
