### PR TITLE
Fix 'make (un)install' commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,11 +163,11 @@ endif
 
 .PHONY: install
 install: manifests tools ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUBECTL) apply -f deploy/charts/prefect-operator/crds/*.yaml
+	$(KUBECTL) apply -f 'deploy/charts/prefect-operator/crds/*.yaml'
 
 .PHONY: uninstall
 uninstall: manifests tools ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f deploy/charts/prefect-operator/crds/*.yaml
+	$(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f 'deploy/charts/prefect-operator/crds/*.yaml'
 
 .PHONY: deploy
 deploy: helmbuild ## Install CRDs & the Helm Chart to the K8s cluster specified in ~/.kube/config.


### PR DESCRIPTION
## Summary

The wildcard in the 'make (un)install' commands was causing an error locally. At least on my system and shell (zsh), adding the single quotes around the file path fixes it.

Related to https://linear.app/prefect/issue/PLA-289/cycle-2-catch-all


## Testing

Before the change:

```
$ make install
mise all runtimes are installed
pre-commit installed at /Users/mitch/code/github.com/prefecthq/prefect-operator/main/.git/hooks/pre-commit
controller-gen crd webhook paths="./..." output:crd:artifacts:config=deploy/charts/prefect-operator/crds
kubectl apply -f deploy/charts/prefect-operator/crds/*.yaml
error: Unexpected args: [deploy/charts/prefect-operator/crds/prefect.io_prefectworkpools.yaml]
See 'kubectl apply -h' for help and examples
make: *** [install] Error 1
```

After the change:

```
$ make install
mise all runtimes are installed
pre-commit installed at /Users/mitch/code/github.com/prefecthq/prefect-operator/main/.git/hooks/pre-commit
controller-gen crd webhook paths="./..." output:crd:artifacts:config=deploy/charts/prefect-operator/crds
kubectl apply -f 'deploy/charts/prefect-operator/crds/*.yaml'
customresourcedefinition.apiextensions.k8s.io/prefectservers.prefect.io unchanged
customresourcedefinition.apiextensions.k8s.io/prefectworkpools.prefect.io unchanged
```