### PR TITLE
Automate Helm Chart release on `operator` release

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -28,12 +28,12 @@ jobs:
         run: |
           # Enable pipefail so git command failures do not result in null versions downstream
           set -x
-          echo "RELEASE_VERSION=$(date +'%Y.%-m.%-d%H%M%S')" >> $GITHUB_OUTPUT
+          echo "RELEASE_VERSION=$(date +'%Y.%-m.%-d%H%M%S')" >> $GITHUB_ENV
 
           # This ensures that the latest tag we grab will be of the operator image, and not the helm chart
           echo "IMAGE_VERSION=$(\
           git ls-remote --tags --refs --sort="v:refname" \
-          origin 'v[0-9].[0-9].[0-9]' | tail -n1 | sed 's/.*\///' | sed 's/v//')" >> $GITHUB_OUTPUT
+          origin 'v[0-9].[0-9].[0-9]' | tail -n1 | sed 's/.*\///' | sed 's/v//')" >> $GITHUB_ENV
 
       - name: Configure Git
         run: |
@@ -77,11 +77,6 @@ jobs:
             --sign --key 'jamie@prefect.io' \
             --keyring $SIGN_KEYRING \
             --passphrase-file $SIGN_PASSPHRASE_FILE
-        env:
-          IMAGE_VERSION: ${{ steps.get_version.outputs.IMAGE_VERSION }}
-          RELEASE_VERSION: ${{ steps.get_version.outputs.RELEASE_VERSION }}
-          SIGN_KEYRING: ${{ env.SIGN_KEYRING }}
-          SIGN_PASSPHRASE_FILE: ${{ env.SIGN_PASSPHRASE_FILE }}
 
       - name: Update chart index
         run: |
@@ -96,8 +91,6 @@ jobs:
           git add ./index.yaml ./charts/prefect-operator-$RELEASE_VERSION.* ./charts/
           git commit -m "Release $RELEASE_VERSION"
           git push origin gh-pages
-        env:
-          RELEASE_VERSION: ${{ steps.get_version.outputs.RELEASE_VERSION }}
 
       - name: Create Github Release + Tag
         run: |
@@ -106,6 +99,4 @@ jobs:
             --notes "Packaged with prefect-operator version \
             [v$IMAGE_VERSION](https://github.com/PrefectHQ/prefect-operator/releases/tag/v$IMAGE_VERSION)"
         env:
-          IMAGE_VERSION: ${{ steps.get_version.outputs.IMAGE_VERSION }}
-          GITHUB_TOKEN: ${{ github.token }}
-          RELEASE_VERSION: ${{ steps.get_version.outputs.RELEASE_VERSION }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/helm-unittest.yaml
+++ b/.github/workflows/helm-unittest.yaml
@@ -10,7 +10,6 @@ name: Run Helm unit tests
     paths:
       - deploy/charts/**
 
-# Do not grant jobs any permissions by default
 permissions: {}
 
 jobs:

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -6,7 +6,7 @@ name: Labeler
       - opened
 
 jobs:
-  apply-label:
+  apply_label:
     runs-on: ubuntu-latest
     steps:
       - name: Apply prefect-operator label to all issues

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,11 +17,13 @@ jobs:
   run_unit_tests:
     uses: ./.github/workflows/tests.yaml
     permissions:
+      # required by downstream jobs
       contents: read
 
   build_and_upload_manifests:
     if: github.ref_type == 'tag'
     permissions:
+      # required to write artifacts to a release
       contents: write
     runs-on: ubuntu-latest
     steps:
@@ -51,8 +53,6 @@ jobs:
           yq -i '(.. | select(tag == "!!str" and . == "v0.0.0")) |= "${{ github.ref_name }}"' prefect-operator.yaml
 
       - name: Upload release assets
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ github.ref_name }} prefect-crds.yaml prefect-operator.yaml
 
   build_and_push_docker_image:
@@ -104,6 +104,7 @@ jobs:
   create_helm_release:
     if: github.ref_type == 'tag'
     permissions:
+      # required by downstream jobs
       contents: write
     needs: build_and_push_docker_image
     uses: ./.github/workflows/helm-release.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,6 +101,8 @@ jobs:
 
   create_helm_release:
     if: github.ref_type == 'tag'
+    permissions:
+      contents: write
     needs: build_and_push_docker_image
     uses: ./.github/workflows/helm-release.yaml
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,6 +119,7 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
 
   create_helm_release:
+    if: github.ref_type == 'tag'
     needs: build_and_push_docker_image
     uses: ./.github/workflows/helm-release.yaml
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,10 +7,18 @@ name: Release Prefect Operator
       - main
     tags:
       - '*'
+  pull_request:
+    branches:
+      - main
 
 permissions: {}
 
 jobs:
+  run_unit_tests:
+    uses: ./.github/workflows/tests.yaml
+    permissions:
+      contents: read
+
   build_and_upload_manifests:
     if: github.ref_type == 'tag'
     permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,29 +14,11 @@ name: Release Prefect Operator
 permissions: {}
 
 jobs:
-  unit_tests:
-    name: Unit tests
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Install tool dependencies
-        uses: jdx/mise-action@v2
-        with:
-          experimental: true
-
-      - name: Build
-        run: make build
-
-      - name: Test
-        run: make test
+  run_unit_tests:
+    uses: ./.github/workflows/tests.yaml
 
   build_and_upload_manifests:
     if: github.ref_type == 'tag'
-    needs: unit_tests
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -72,7 +54,6 @@ jobs:
         run: gh release upload ${{ github.ref_name }} prefect-crds.yaml prefect-operator.yaml
 
   build_and_push_docker_image:
-    needs: unit_tests
     runs-on: ubuntu-latest
     # The GitHub environments are created by Terraform and map to Docker Hub repositories:
     # - dev: https://hub.docker.com/r/prefecthq/prefect-operator-dev

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,8 @@ permissions: {}
 jobs:
   run_unit_tests:
     uses: ./.github/workflows/tests.yaml
+    permissions:
+      contents: read
 
   build_and_upload_manifests:
     if: github.ref_type == 'tag'
@@ -101,8 +103,7 @@ jobs:
 
   create_helm_release:
     if: github.ref_type == 'tag'
-    permissions:
-      contents: write
     needs: build_and_push_docker_image
     uses: ./.github/workflows/helm-release.yaml
-    secrets: inherit
+		permissions:
+			contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,9 +102,8 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
 
   create_helm_release:
-		if: github.ref_type == 'tag'
-		permissions:
-			contents: write
-		needs: build_and_push_docker_image
-		uses: ./.github/workflows/helm-release.yaml
-
+    if: github.ref_type == 'tag'
+    permissions:
+      contents: write
+    needs: build_and_push_docker_image
+    uses: ./.github/workflows/helm-release.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,8 +102,9 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
 
   create_helm_release:
-    if: github.ref_type == 'tag'
-    needs: build_and_push_docker_image
-    uses: ./.github/workflows/helm-release.yaml
+		if: github.ref_type == 'tag'
 		permissions:
 			contents: write
+		needs: build_and_push_docker_image
+		uses: ./.github/workflows/helm-release.yaml
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,18 +7,10 @@ name: Release Prefect Operator
       - main
     tags:
       - '*'
-  pull_request:
-    branches:
-      - main
 
 permissions: {}
 
 jobs:
-  run_unit_tests:
-    uses: ./.github/workflows/tests.yaml
-    permissions:
-      contents: read
-
   build_and_upload_manifests:
     if: github.ref_type == 'tag'
     permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,5 @@
 ---
-name: prefect-operator release
+name: Release Prefect Operator
 
 "on":
   push:
@@ -14,7 +14,7 @@ name: prefect-operator release
 permissions: {}
 
 jobs:
-  unit-tests:
+  unit_tests:
     name: Unit tests
     runs-on: ubuntu-latest
     permissions:
@@ -34,9 +34,9 @@ jobs:
       - name: Test
         run: make test
 
-  build-and-upload-manifests:
+  build_and_upload_manifests:
     if: github.ref_type == 'tag'
-    needs: unit-tests
+    needs: unit_tests
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -71,8 +71,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ github.ref_name }} prefect-crds.yaml prefect-operator.yaml
 
-  build-and-push-docker-image:
-    needs: unit-tests
+  build_and_push_docker_image:
+    needs: unit_tests
     runs-on: ubuntu-latest
     # The GitHub environments are created by Terraform and map to Docker Hub repositories:
     # - dev: https://hub.docker.com/r/prefecthq/prefect-operator-dev
@@ -117,3 +117,8 @@ jobs:
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
+
+  create_helm_release:
+    needs: build_and_push_docker_image
+    uses: ./.github/workflows/helm-release.yaml
+    secrets: inherit

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -24,6 +24,7 @@ jobs:
     name: pre-commit checks
     runs-on: ubuntu-latest
     permissions:
+      # required to read from the repo
       contents: read
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -4,6 +4,8 @@ name: Static analysis
 "on":
   pull_request: {}
 
+permissions: {}
+
 # Limit concurrency by workflow/branch combination.
 #
 # For pull request builds, pushing additional changes to the
@@ -21,6 +23,8 @@ jobs:
   pre_commit_checks:
     name: pre-commit checks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -2,7 +2,7 @@
 name: Static analysis
 
 "on":
-  pull_request:
+  pull_request: {}
 
 # Limit concurrency by workflow/branch combination.
 #
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  pre-commit-checks:
+  pre_commit_checks:
     name: pre-commit checks
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,10 +2,7 @@
 name: Unit tests
 
 "on":
-  pull_request: {}
-  push:
-    branches:
-      - main
+  workflow_call: {}
 
 permissions: {}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,6 @@ name: Unit tests
   push:
     branches:
       - main
-  workflow_call: {}
 
 permissions: {}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,36 @@
+---
+name: Unit tests
+
+"on":
+  pull_request: {}
+  push:
+    branches:
+      - main
+  workflow_call: {}
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  unit_tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install tool dependencies
+        uses: jdx/mise-action@v2
+        with:
+          experimental: true # enables the go installation backend
+
+      - name: Build
+        run: make build
+
+      - name: Test
+        run: make test

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,7 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     permissions:
+      # required to read from the repo
       contents: read
     steps:
       - name: Check out code

--- a/.github/workflows/update-helm-versions.yaml
+++ b/.github/workflows/update-helm-versions.yaml
@@ -2,7 +2,7 @@
 name: Updatecli dependency updates
 
 "on":
-  workflow_dispatch:
+  workflow_dispatch: {}
   schedule:
     # The first of each month at 10am EST
     - cron: 0 15 1 * *
@@ -30,24 +30,22 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
-      - name: create branch for helm version updates
+      - name: Create branch for helm version updates
         run: |
           git checkout -b "helm-version-${{ steps.date.outputs.date }}"
 
-      - name: install updatecli in the runner
+      - name: Install updatecli in the runner
         uses: updatecli/updatecli-action@v2
 
-      - name: run updatecli in apply mode
+      - name: Run updatecli in apply mode
         run: |
           updatecli apply --config .github/updatecli/manifest.yaml
           git commit -am "helm-version-${{ steps.date.outputs.date }}"
           git push --set-upstream origin "helm-version-${{ steps.date.outputs.date }}"
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
 
-      - name: create pr
+      - name: Create pr
         run: |
           git checkout "helm-version-${{ steps.date.outputs.date }}"
           gh pr create --base main --title "helm-version-bump-${{ steps.date.outputs.date }}" -b "please run helm-docs locally to update chart readmes" --label dependencies
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/update-helm-versions.yaml
+++ b/.github/workflows/update-helm-versions.yaml
@@ -13,7 +13,7 @@ jobs:
   updatecli:
     runs-on: ubuntu-latest
     permissions:
-      # required to write to the repo
+      # required to commit to a branch
       contents: write
       # required to open a pr with updatecli changes
       pull-requests: write

--- a/.github/workflows/validate-updatecli-config.yaml
+++ b/.github/workflows/validate-updatecli-config.yaml
@@ -28,5 +28,3 @@ jobs:
       - name: run updatecli diff to validate config
         run: |
           updatecli diff --config .github/updatecli/manifest.yaml
-        env:
-          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This PR also:
- updates workflow files to use `_` instead of `-`
- removes `env` specifications where not neccessary
- updates `GITHUB_TOKEN` -> `GH_TOKEN` when using the github cli
- separates `tests` into their own workflow

Closes PLA-349