### PR TITLE
fix: allow helm-release workflow to inherit secrets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
 
   build_and_upload_manifests:
     if: github.ref_type == 'tag'
+    needs: run_unit_tests
     permissions:
       # required to write artifacts to a release
       contents: write
@@ -54,8 +55,11 @@ jobs:
 
       - name: Upload release assets
         run: gh release upload ${{ github.ref_name }} prefect-crds.yaml prefect-operator.yaml
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   build_and_push_docker_image:
+    needs: run_unit_tests
     runs-on: ubuntu-latest
     # The GitHub environments are created by Terraform and map to Docker Hub repositories:
     # - dev: https://hub.docker.com/r/prefecthq/prefect-operator-dev

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -107,8 +107,11 @@ jobs:
 
   create_helm_release:
     if: github.ref_type == 'tag'
+    needs: build_and_push_docker_image
+    uses: ./.github/workflows/helm-release.yaml
     permissions:
       # required by downstream jobs
       contents: write
-    needs: build_and_push_docker_image
-    uses: ./.github/workflows/helm-release.yaml
+    # this is required so that the workflow can read secrets
+    # from the environment
+    secrets: inherit


### PR DESCRIPTION
Also adds some dependencies between the workflows

Relates to [PLA-332](https://linear.app/prefect/issue/PLA-349/automatically-release-prefect-operator-helm-chart-on-prefect-operator)