### PR TITLE
chore: add comment to `Dockerfile` to validate workflows

### DIFF
--- a/.github/workflows/images-prs.yaml
+++ b/.github/workflows/images-prs.yaml
@@ -33,3 +33,4 @@ jobs:
     with:
       environment: dev
       image: prefect-operator-dev
+    secrets: inherit

--- a/.github/workflows/update-helm-versions.yaml
+++ b/.github/workflows/update-helm-versions.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create branch for helm version updates
         run: |
-          git checkout -b "helm-version-$DATE}"
+          git checkout -b "helm-version-$DATE"
 
       - name: Install updatecli in the runner
         uses: updatecli/updatecli-action@v2
@@ -40,8 +40,8 @@ jobs:
       - name: Run updatecli in apply mode
         run: |
           updatecli apply --config .github/updatecli/manifest.yaml
-          git commit -am "helm-version-$DATE}"
-          git push --set-upstream origin "helm-version-$DATE}"
+          git commit -am "helm-version-$DATE"
+          git push --set-upstream origin "helm-version-$DATE"
 
       - name: Install `helm-docs`
         uses: jdx/mise-action@v2
@@ -56,7 +56,7 @@ jobs:
 
       - name: Create pr
         run: |
-          git checkout "helm-version-$DATE}"
-          gh pr create --base main --title "helm-version-bump-$DATE}" --label dependencies
+          git checkout "helm-version-$DATE"
+          gh pr create --base main --title "helm-version-bump-$DATE" --label dependencies
         env:
           GH_TOKEN: ${{ github.token }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,5 @@ WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532
 
+# Entrypoint for the container
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Adds `secrets: inherit` to all workflows that require it, in order to read dockerhub credentials.

Also fixes the updatecli workflow by removing an unnecessary bracket (`}`)