### PR TITLE
Add `run-helm-docs` flag to updatecli action

### DIFF
--- a/.github/updatecli/manifest.yaml
+++ b/.github/updatecli/manifest.yaml
@@ -7,7 +7,6 @@ sources:
       name: common
       versionFilter:
         kind: semver
-        pattern: 2.x.x
     sourceid: common
 conditions: {}
 targets:

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -24,4 +24,5 @@ jobs:
         uses: prefecthq/actions-updatecli-apply@main
         with:
           manifest-path: .github/updatecli/manifest.yaml
+          run-helm-docs: true
           run-type: minor

--- a/Makefile
+++ b/Makefile
@@ -89,10 +89,13 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: helmbuild
-helmbuild: ## Build Helm dependencies
+helmbuild: update-chart-deps ## Build Helm dependencies
 	helm repo add bitnami https://charts.bitnami.com/bitnami
 	helm dependency build $(CHART_PATH)
 
+.PHONY: update-chart-deps
+update-chart-deps:
+	helm dependency update $(CHART_PATH)
 
 GINKGO_OPTIONS ?= -v --skip-package test/e2e -coverprofile cover.out -coverpkg ./api/v1/...,./internal/... -r
 


### PR DESCRIPTION
Relates to [PLA-381](https://linear.app/prefect/issue/PLA-381/re-introduce-helm-docs-into-updatecli-prs-where-applicable)

Depends on https://github.com/PrefectHQ/actions-updatecli-apply/pull/4