### PR TITLE
CI: always push short sha image tags

### DIFF
--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -41,8 +41,13 @@ jobs:
         with:
           images: prefecthq/${{ inputs.image }}
           tags: |
+            # always: short sha
+            type=sha,prefix=,format=short
+            # for pull requests: "pr-123"
             type=ref,event=pr
-            type=ref,event=branch
+            # for main merges: latest
+            type=raw,value=latest,enable={{is_default_branch}}
+            # for releases: 1.2.3
             type=semver,pattern={{version}}
           labels: |
             org.opencontainers.image.title=prefect-operator


### PR DESCRIPTION
Follows the pattern we use in the prefect-cloud-operator, always pushing the short sha. This is currently used for updating the version running in dev but will likely be handy in the future to refer to specific image versions as well.

Also:
- adds comments explaining what each tag spec does
- adds the 'latest' tag for main merges

Related to https://linear.app/prefect/issue/PLA-343/automatically-update-prefect-operator-helm-chart-versions-in-ccd-to