### PR TITLE
Remove newline in init function

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,7 +48,6 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-
 	utilruntime.Must(prefectiov1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }


### PR DESCRIPTION
Removes the newline in the init function. Mostly just making an arbitrary change to trigger a build of the image on `main` that will push the short sha as added in https://github.com/PrefectHQ/prefect-operator/pull/108

Related to https://linear.app/prefect/issue/PLA-343/automatically-update-prefect-operator-helm-chart-versions-in-ccd-to