### PR TITLE
Fix operatorVersion output

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -34,9 +34,10 @@ jobs:
           echo "RELEASE_VERSION=$(date +'%Y.%-m.%-d%H%M%S')" >> $GITHUB_ENV
 
           # This ensures that the latest tag we grab will be of the operator image, and not the helm chart
-          echo "IMAGE_VERSION=$(\
+          echo "OPERATOR_VERSION=$(\
           git ls-remote --tags --refs --sort="v:refname" \
-          origin 'v[0-9].[0-9].[0-9]' | tail -n1 | sed 's/.*\///' | sed 's/v//')" >> $GITHUB_ENV
+          origin 'v[0-9].[0-9].[0-9]' | tail -n1 | sed 's/.*\///'
+          )" >> $GITHUB_ENV
 
       - name: Output versions as GitHub Outputs
         id: output_versions


### PR DESCRIPTION
Related to https://linear.app/prefect/issue/PLA-343/automatically-update-prefect-operator-helm-chart-versions-in-ccd-to

Should fix https://github.com/PrefectHQ/prefect-operator/actions/runs/11261117935/job/31313838170:

```
Run gh workflow run update-prefect-operator-versions.yaml \
  gh workflow run update-prefect-operator-versions.yaml \
    --repo prefecthq/cloud2-cluster-deployment \
    --ref main \
    -f image_version= \
    -f chart_version=2024.10.9184342 \
    -f mode=release
  shell: /usr/bin/bash -e {0}
  env:
    GH_TOKEN: ***
could not create workflow dispatch event: HTTP 422: Required input 'image_version' not provided ([https://api.github.com/repos/prefecthq/cloud2-cluster-deployment/actions/](https://api.github.com/repos/prefecthq/cloud2-cluster-deployment/actions/workflows/121725690/dispatches)
```