### PR TITLE
Update dev image version in CCD on main merge

### DIFF
--- a/.github/workflows/images-main.yaml
+++ b/.github/workflows/images-main.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Get image version
         run: |
           short_sha="$(git rev-parse --short=7 HEAD)"
-          echo "SHORT_SHA=$short_sha" >> "$GITHUB_ENV"
+          echo "SHORT_SHA=$short_sha" >> $GITHUB_ENV
 
       - name: Run workflow
         run: |

--- a/.github/workflows/images-main.yaml
+++ b/.github/workflows/images-main.yaml
@@ -28,3 +28,30 @@ jobs:
       image: prefect-operator-dev
     # this is required so that the workflow can read secrets rom the environment
     secrets: inherit
+
+  update_image_version_downstream:
+    name: Update dev/stg image versions in `cloud2-cluster-deployment`
+    needs: build_and_push_image_for_main
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get image version
+        run: |
+          short_sha="$(git rev-parse --short=7 HEAD)"
+          echo "SHORT_SHA=$short_sha" >> "$GITHUB_ENV"
+
+      - name: Run workflow
+        run: |
+          gh workflow run update-prefect-operator-versions.yaml \
+            --repo prefecthq/cloud2-cluster-deployment \
+            --ref main \
+            -f image_version=$SHORT_SHA \
+            -f mode=main-merge
+        env:
+          GH_TOKEN: ${{ secrets.CLOUD2_CLUSTER_DEPLOYMENT_ACTIONS_RW }}


### PR DESCRIPTION
Related to https://linear.app/prefect/issue/PLA-343/automatically-update-prefect-operator-helm-chart-versions-in-ccd-to