### PR TITLE
Apply 'app' and 'version' labels to Server Pods

### DIFF
--- a/api/v1/prefectserver_types.go
+++ b/api/v1/prefectserver_types.go
@@ -237,6 +237,8 @@ type PrefectServer struct {
 func (s *PrefectServer) ServerLabels() map[string]string {
 	labels := map[string]string{
 		"prefect.io/server": s.Name,
+		"app":               "prefect-server",
+		"version":           s.getVersion(),
 	}
 	for k, v := range s.Spec.DeploymentLabels {
 		labels[k] = v
@@ -338,4 +340,15 @@ type PrefectServerList struct {
 
 func init() {
 	SchemeBuilder.Register(&PrefectServer{}, &PrefectServerList{})
+}
+
+// getVersion returns the version of Prefect.
+// The `.spec.version` field is optional, so if it is
+// not configured, we return the default version.
+func (s *PrefectServer) getVersion() string {
+	if s.Spec.Version != nil && *s.Spec.Version != "" {
+		return *s.Spec.Version
+	}
+
+	return DEFAULT_PREFECT_VERSION
 }


### PR DESCRIPTION
Applies 'app' and 'version' labels to Server Pods. This is a fairly common Kubernetes standard, and also allows better tracing in Kiali for Istio mesh network visualization.

Reference: https://linear.app/prefect/issue/PLA-410/istio-investigate-ambient-mode#comment-3ade7c6c

Related to https://linear.app/prefect/issue/PLA-422/reintroduce-kiali-to-cloud2-cluster-deployment

Related to PLA-410