### PR TITLE
Lower migration job TTL

### DIFF
--- a/internal/controller/prefectserver_controller.go
+++ b/internal/controller/prefectserver_controller.go
@@ -528,7 +528,7 @@ func (r *PrefectServerReconciler) postgresDeploymentSpec(server *prefectiov1.Pre
 
 func (r *PrefectServerReconciler) postgresMigrationJob(server *prefectiov1.PrefectServer) *batchv1.Job {
 	jobSpec := batchv1.JobSpec{
-		TTLSecondsAfterFinished: ptr.To(int32(7 * 24 * 60 * 60)), // 7 days
+		TTLSecondsAfterFinished: ptr.To(int32(60 * 60)), // 1 hour
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: server.MigrationJobLabels(),

--- a/internal/utils/hash_test.go
+++ b/internal/utils/hash_test.go
@@ -16,7 +16,7 @@ func MigrationJobStub() *batchv1.Job {
 			Namespace: "default",
 		},
 		Spec: batchv1.JobSpec{
-			TTLSecondsAfterFinished: ptr.To(int32(7 * 24 * 60 * 60)), // 7 days
+			TTLSecondsAfterFinished: ptr.To(int32(60 * 60)), // 1 hour
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{"app": "prefect-server"},


### PR DESCRIPTION
Lowers the job TTL from 7 days to 1 hour.

This should greatly reduce the number of completed Jobs sitting around in the cluster, which will free up a significant number of IPs (and clutter).

We may end up wanting to make this configurable in the PrefectServer spec.

Context: https://linear.app/prefect/document/prefect-load-testing-notes-b87465895445

Related to https://linear.app/prefect/issue/PLA-435/determine-appropriate-ttl-for-jobs-created-by-the-prefect-operator