### PR TITLE
Add short name ps & pwp for Server & Workpool crds

### DIFF
--- a/deploy/charts/prefect-operator/crds/prefect.io_prefectservers.yaml
+++ b/deploy/charts/prefect-operator/crds/prefect.io_prefectservers.yaml
@@ -12,6 +12,8 @@ spec:
     listKind: PrefectServerList
     plural: prefectservers
     singular: prefectserver
+    shortNames:
+    - ps
   scope: Namespaced
   versions:
   - additionalPrinterColumns:

--- a/deploy/charts/prefect-operator/crds/prefect.io_prefectworkpools.yaml
+++ b/deploy/charts/prefect-operator/crds/prefect.io_prefectworkpools.yaml
@@ -12,6 +12,8 @@ spec:
     listKind: PrefectWorkPoolList
     plural: prefectworkpools
     singular: prefectworkpool
+    shortNames:
+    - pwp
   scope: Namespaced
   versions:
   - additionalPrinterColumns:


### PR DESCRIPTION
Relates to https://linear.app/prefect/issue/PLA-598/add-short-names-to-all-three-prefect-crds