### PR TITLE
chore: only create GitHub releases on mode release

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -101,7 +101,7 @@ jobs:
             --destination /tmp/chart \
             --dependency-update \
             --version $RELEASE_VERSION \
-            --app-version v$OPERATOR_VERSION \
+            --app-version $OPERATOR_VERSION \
             --sign --key 'jamie@prefect.io' \
             --keyring $SIGN_KEYRING \
             --passphrase-file $SIGN_PASSPHRASE_FILE
@@ -121,12 +121,13 @@ jobs:
           git push origin gh-pages
 
       - name: Create Github Release + Tag
+        if: ${{ inputs.mode == 'release' }}
         run: |
           gh release create $RELEASE_VERSION \
             --title $RELEASE_VERSION \
             --latest=false \
             --notes "Packaged with prefect-operator version \
-            [v$OPERATOR_VERSION](https://github.com/PrefectHQ/prefect-operator/releases/tag/v$OPERATOR_VERSION)"
+            [$OPERATOR_VERSION](https://github.com/PrefectHQ/prefect-operator/releases/tag/$OPERATOR_VERSION)"
         env:
           GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
Also removes proceeding `v` from the `image` version in the GitHub release description.
![Screenshot 2024-10-31 at 10 15 52 PM](https://github.com/user-attachments/assets/fa92f343-6f38-4f27-bd72-4d3c5d2c4925)

Relates to https://linear.app/prefect/issue/PLA-407/handle-dev-helm-chart-releases-description