### PR TITLE
Support setting extra args in Deployment command

### DIFF
--- a/api/v1/prefectserver_types.go
+++ b/api/v1/prefectserver_types.go
@@ -45,6 +45,9 @@ type PrefectServerSpec struct {
 	// ExtraServicePorts defines additional ports to expose on the Prefect Server Service
 	ExtraServicePorts []corev1.ServicePort `json:"extraServicePorts,omitempty"`
 
+	// ExtraArgs defines additional arguments to pass to the Prefect Server Deployment
+	ExtraArgs []string `json:"extraArgs,omitempty"`
+
 	// Ephemeral defines whether the Prefect Server will be deployed with an ephemeral storage backend
 	Ephemeral *EphemeralConfiguration `json:"ephemeral,omitempty"`
 
@@ -281,7 +284,10 @@ func (s *PrefectServer) Image() string {
 }
 
 func (s *PrefectServer) Command() []string {
-	return []string{"prefect", "server", "start", "--host", "0.0.0.0"}
+	command := []string{"prefect", "server", "start", "--host", "0.0.0.0"}
+	command = append(command, s.Spec.ExtraArgs...)
+
+	return command
 }
 
 func (s *PrefectServer) ToEnvVars() []corev1.EnvVar {

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -253,6 +253,11 @@ func (in *PrefectServerSpec) DeepCopyInto(out *PrefectServerSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ExtraArgs != nil {
+		in, out := &in.ExtraArgs, &out.ExtraArgs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Ephemeral != nil {
 		in, out := &in.Ephemeral, &out.Ephemeral
 		*out = new(EphemeralConfiguration)

--- a/deploy/charts/prefect-operator/crds/prefect.io_prefectservers.yaml
+++ b/deploy/charts/prefect-operator/crds/prefect.io_prefectservers.yaml
@@ -60,6 +60,12 @@ spec:
                 description: Ephemeral defines whether the Prefect Server will be
                   deployed with an ephemeral storage backend
                 type: object
+              extraArgs:
+                description: ExtraArgs defines additional arguments to pass to the
+                  Prefect Server Deployment
+                items:
+                  type: string
+                type: array
               extraContainers:
                 description: ExtraContainers defines additional containers to add
                   to the Prefect Server Deployment

--- a/internal/controller/prefectserver_controller_test.go
+++ b/internal/controller/prefectserver_controller_test.go
@@ -602,6 +602,35 @@ var _ = Describe("PrefectServer controller", func() {
 				port := service.Spec.Ports[1]
 				Expect(port.Name).To(Equal("extra-port"))
 			})
+
+			It("should update the Command with the extra args", func() {
+				// Update the PrefectServer with an extra args
+				Expect(k8sClient.Get(ctx, name, prefectserver)).To(Succeed())
+				prefectserver.Spec.ExtraArgs = []string{"--some-arg", "some-value"}
+
+				Expect(k8sClient.Update(ctx, prefectserver)).To(Succeed())
+				// Reconcile to apply the changes
+				controllerReconciler := &PrefectServerReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: name,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Check if the Deployment was updated with the extra args
+				deployment := &appsv1.Deployment{}
+				Eventually(func() error {
+					return k8sClient.Get(ctx, types.NamespacedName{
+						Namespace: namespaceName,
+						Name:      "prefect-on-anything",
+					}, deployment)
+				}).Should(Succeed())
+
+				container := deployment.Spec.Template.Spec.Containers[0]
+				Expect(container.Command).To(Equal([]string{"prefect", "server", "start", "--host", "0.0.0.0", "--some-arg", "some-value"}))
+			})
 		})
 
 		Context("When evaluating changes with any server", func() {


### PR DESCRIPTION
Supports setting extra args in the Deployment command.

This will allow us to set `--no-ui` in cases where we don't need to serve the UI.

Related to https://linear.app/prefect/issue/PLA-452/cycle-5-catch-all