### PR TITLE
Fix image tag for release mode

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -138,10 +138,19 @@ jobs:
     steps:
       - name: Run workflow
         run: |
+          operator_version=${{ needs.release.outputs.operatorVersion }}
+
+          # Trim the 'v' prefix from the version to match the image tag.
+          # Only do this when mode is 'release', in other scenarios the
+          # value here is a short SHA, which could also start with a 'v'.
+          if [[ "${{ inputs.mode }}" == "release" ]]; then
+            operator_version=${operator_version#v}
+          fi
+
           gh workflow run update-operator-versions.yaml \
             --repo prefecthq/cloud2-cluster-deployment \
             --ref main \
-            -f image_version=${{ needs.release.outputs.operatorVersion }} \
+            -f image_version=${image_version} \
             -f chart_version=${{ needs.release.outputs.releaseVersion }} \
             -f mode=${{ inputs.mode }} \
             -f operator=prefect-operator


### PR DESCRIPTION
When the input mode is 'release', we need to trim the 'v' prefix because the container image tags don't have that prefix. This has caused the prefect-operator Deployment in the staging environment to fail with "ImagePullBackOff".

Closes https://linear.app/prefect/issue/PLA-634/prefect-operator-deployment-in-stg-in-imagepullbackoff

<img width="716" alt="image" src="https://github.com/user-attachments/assets/039480a8-e829-4c88-af98-6b63f95f2b58">
