### PR TITLE
chore: update depbot to apply consistent label to all PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,5 +3,26 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    commit-message:
+      prefix: chore
+    groups:
+      all:
+        patterns:
+          - "*"
+    labels:
+      - automated-dependency-updates
     schedule:
-      interval: weekly
+      interval: monthly
+
+  - package-ecosystem: gomod
+    directory: /
+    commit-message:
+      prefix: chore
+    groups:
+      all:
+        patterns:
+          - "*"
+    labels:
+      - automated-dependency-updates
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Also add `go` dependency update

Related to [PLA-703](https://linear.app/prefect/issue/PLA-703/ensure-all-automated-prs-share-a-pr-label)