### PR TITLE
Add make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,8 +188,6 @@ deploy: helmbuild ## Install CRDs & the Helm Chart to the K8s cluster specified 
 undeploy: ## Uninstall the Helm Chart to the K8s cluster specified in ~/.kube/config.
 	helm uninstall $(RELEASE_NAME) --namespace $(NAMESPACE)
 
-##@ Dependencies
-
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,11 @@ SHELL = /usr/bin/env bash -o pipefail
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
+.PHONY: clean
+clean: ## Clean up the project directory.
+	@$(ENVTEST) cleanup $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN)
+	@rm -rf $(LOCALBIN)
+
 ##@ Development
 
 .PHONY: manifests


### PR DESCRIPTION
Add Make target to clean up project directory

Adds a Makefile target to clean up the project directory of any
generated files.

The first one added here is to clean up the kubebuilder binaries, which
are write-protected and therefore cannot be removed with 'rm -rf'.

Related to https://linear.app/prefect/issue/PLA-690/cycle-6-catch-all