### PR TITLE
Fixes Prefect image command-line arguments and labels

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
 actionlint = '1.7.1'
-ginkgo = '2.21.0'
+ginkgo = '2.22.2'
 golang = '1.22'
 golangci-lint = '1.61.0'
 'go:golang.org/x/tools/cmd/goimports' = '0.25.0'

--- a/api/v1/prefectserver_types.go
+++ b/api/v1/prefectserver_types.go
@@ -245,7 +245,6 @@ func (s *PrefectServer) ServerLabels() map[string]string {
 	labels := map[string]string{
 		"prefect.io/server": s.Name,
 		"app":               "prefect-server",
-		"version":           s.getVersion(),
 	}
 	for k, v := range s.Spec.DeploymentLabels {
 		labels[k] = v
@@ -283,7 +282,7 @@ func (s *PrefectServer) Image() string {
 	return DEFAULT_PREFECT_IMAGE
 }
 
-func (s *PrefectServer) Command() []string {
+func (s *PrefectServer) EntrypointArugments() []string {
 	command := []string{"prefect", "server", "start", "--host", "0.0.0.0"}
 	command = append(command, s.Spec.ExtraArgs...)
 
@@ -350,15 +349,4 @@ type PrefectServerList struct {
 
 func init() {
 	SchemeBuilder.Register(&PrefectServer{}, &PrefectServerList{})
-}
-
-// getVersion returns the version of Prefect.
-// The `.spec.version` field is optional, so if it is
-// not configured, we return the default version.
-func (s *PrefectServer) getVersion() string {
-	if s.Spec.Version != nil && *s.Spec.Version != "" {
-		return *s.Spec.Version
-	}
-
-	return DEFAULT_PREFECT_VERSION
 }

--- a/api/v1/prefectworkpool_types.go
+++ b/api/v1/prefectworkpool_types.go
@@ -144,7 +144,7 @@ func (s *PrefectWorkPool) Image() string {
 	return DEFAULT_PREFECT_IMAGE + suffix
 }
 
-func (s *PrefectWorkPool) Command() []string {
+func (s *PrefectWorkPool) EntrypointArguments() []string {
 	workPoolName := s.Name
 	if strings.HasPrefix(workPoolName, "prefect") {
 		workPoolName = "pool-" + workPoolName

--- a/internal/controller/prefectserver_controller.go
+++ b/internal/controller/prefectserver_controller.go
@@ -355,7 +355,7 @@ func (r *PrefectServerReconciler) ephemeralDeploymentSpec(server *prefectiov1.Pr
 						Image:           server.Image(),
 						ImagePullPolicy: corev1.PullIfNotPresent,
 
-						Command: server.Command(),
+						Args: server.EntrypointArugments(),
 						VolumeMounts: []corev1.VolumeMount{
 							{
 								Name:      "prefect-data",
@@ -438,7 +438,7 @@ func (r *PrefectServerReconciler) sqliteDeploymentSpec(server *prefectiov1.Prefe
 						Image:           server.Image(),
 						ImagePullPolicy: corev1.PullIfNotPresent,
 
-						Command: server.Command(),
+						Args: server.EntrypointArugments(),
 						VolumeMounts: []corev1.VolumeMount{
 							{
 								Name:      "prefect-data",
@@ -499,7 +499,7 @@ func (r *PrefectServerReconciler) postgresDeploymentSpec(server *prefectiov1.Pre
 						Image:           server.Image(),
 						ImagePullPolicy: corev1.PullIfNotPresent,
 
-						Command: server.Command(),
+						Args: server.EntrypointArugments(),
 						Env: append(
 							append(
 								server.ToEnvVars(),

--- a/internal/controller/prefectserver_controller_test.go
+++ b/internal/controller/prefectserver_controller_test.go
@@ -156,8 +156,6 @@ var _ = Describe("PrefectServer controller", func() {
 			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 			container := deployment.Spec.Template.Spec.Containers[0]
 			Expect(container.Image).To(Equal(expectedImage))
-			Expect(deployment.Spec.Selector.MatchLabels).To(HaveKeyWithValue("version", version))
-			Expect(deployment.Spec.Template.ObjectMeta.Labels).To(HaveKeyWithValue("version", version))
 		})
 
 		Context("when creating any server", func() {
@@ -277,26 +275,25 @@ var _ = Describe("PrefectServer controller", func() {
 					Expect(deployment.Spec.Selector.MatchLabels).To(Equal(map[string]string{
 						"prefect.io/server": "prefect-on-anything",
 						"app":               "prefect-server",
-						"version":           prefectiov1.DEFAULT_PREFECT_VERSION,
 						"some":              "additional-label",
 						"another":           "extra-label",
 					}))
 					Expect(deployment.Spec.Template.Labels).To(Equal(map[string]string{
 						"prefect.io/server": "prefect-on-anything",
 						"app":               "prefect-server",
-						"version":           prefectiov1.DEFAULT_PREFECT_VERSION,
 						"some":              "additional-label",
 						"another":           "extra-label",
 					}))
 				})
 
-				It("should have a server container with the right image and command", func() {
+				It("should have a server container with the right image and entrypoint arguments", func() {
 					Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 					container := deployment.Spec.Template.Spec.Containers[0]
 
 					Expect(container.Name).To(Equal("prefect-server"))
 					Expect(container.Image).To(Equal("prefecthq/prefect:3.1.13-python3.12"))
-					Expect(container.Command).To(Equal([]string{"prefect", "server", "start", "--host", "0.0.0.0"}))
+					Expect(container.Command).To(BeNil())
+					Expect(container.Args).To(Equal([]string{"prefect", "server", "start", "--host", "0.0.0.0"}))
 				})
 
 				It("should have an environment with PREFECT_HOME set", func() {
@@ -603,7 +600,7 @@ var _ = Describe("PrefectServer controller", func() {
 				Expect(port.Name).To(Equal("extra-port"))
 			})
 
-			It("should update the Command with the extra args", func() {
+			It("should update the entrypoint arguments with the extra args", func() {
 				// Update the PrefectServer with an extra args
 				Expect(k8sClient.Get(ctx, name, prefectserver)).To(Succeed())
 				prefectserver.Spec.ExtraArgs = []string{"--some-arg", "some-value"}
@@ -629,7 +626,8 @@ var _ = Describe("PrefectServer controller", func() {
 				}).Should(Succeed())
 
 				container := deployment.Spec.Template.Spec.Containers[0]
-				Expect(container.Command).To(Equal([]string{"prefect", "server", "start", "--host", "0.0.0.0", "--some-arg", "some-value"}))
+				Expect(container.Command).To(BeNil())
+				Expect(container.Args).To(Equal([]string{"prefect", "server", "start", "--host", "0.0.0.0", "--some-arg", "some-value"}))
 			})
 		})
 

--- a/internal/controller/prefectworkpool_controller.go
+++ b/internal/controller/prefectworkpool_controller.go
@@ -113,7 +113,7 @@ func (r *PrefectWorkPoolReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 							Image:           workPool.Image(),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 
-							Command: workPool.Command(),
+							Args: workPool.EntrypointArguments(),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "prefect-data",

--- a/internal/controller/prefectworkpool_controller_test.go
+++ b/internal/controller/prefectworkpool_controller_test.go
@@ -252,7 +252,8 @@ var _ = Describe("PrefectWorkPool Controller", func() {
 
 				Expect(container.Name).To(Equal("prefect-worker"))
 				Expect(container.Image).To(Equal("prefecthq/prefect:3.0.0-python3.12-kubernetes"))
-				Expect(container.Command).To(Equal([]string{
+				Expect(container.Command).To(BeNil())
+				Expect(container.Args).To(Equal([]string{
 					"prefect", "worker", "start",
 					"--pool", "example-work-pool", "--type", "kubernetes",
 					"--with-healthcheck",


### PR DESCRIPTION
We were passing `Command` to the Prefect `server` container, which in
K8s would bypass the configured `CMD` of the Prefect Docker image.  We
want to preserve the Prefect entrypoint and pass our command as the
_arguments_ to that entrypoint.  This allows us to do things like pass
`EXTRA_PIP_PACKAGES` and have the Prefect entrypoint script install
them.

We were also applying the server's version as a label on the deployment
and its pods, but those labels are immutable after creation.  This means
we can't update the version of the Prefect server.  We don't need the
version stamped as a label, as we will have the version definitively in
the `Image` of the container.  If we find we need it as metadata, we can
put it in an annotation later.
