### PR TITLE
chore(CI): skip docker login on PR workflows

### DIFF
--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -12,6 +12,11 @@ name: Build and Push Image
         description: Image name (without the tag & registry)
         required: true
         type: string
+      docker-login:
+        description: Whether to log in to Docker Hub
+        required: false
+        type: boolean
+        default: true
       push:
         description: Whether to push the image to the registry
         required: false
@@ -34,6 +39,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
+        if: ${{ inputs.docker-login }}
         with:
           # These credentials are managed in Terraform. Depending on the 'environment' value above,
           # these will either be the credentials for 'dev' or 'prod'.

--- a/.github/workflows/images-prs.yaml
+++ b/.github/workflows/images-prs.yaml
@@ -40,6 +40,7 @@ jobs:
       id-token: write
       security-events: write
     with:
+      docker-login: false
       push: false
       environment: dev
       image: prefect-operator-dev

--- a/.github/workflows/images-prs.yaml
+++ b/.github/workflows/images-prs.yaml
@@ -1,5 +1,5 @@
 ---
-name: Build and Push Images on Pull Requests
+name: Build Images on Pull Requests
 
 "on":
   pull_request:


### PR DESCRIPTION
We don't push docker images on PR workflows, so no need to `docker login` either. This was causing problems in fork pipelines because the login credentials weren't available (as expected).

Closes https://github.com/PrefectHQ/prefect-operator/issues/156

<img width="287" alt="image" src="https://github.com/user-attachments/assets/1c06c54b-e6a3-4f95-ba13-9d2a1ecd11e1" />