### PR TITLE
Improve error handling in SetControllerReference calls

### DIFF
--- a/internal/controller/prefectserver_controller_test.go
+++ b/internal/controller/prefectserver_controller_test.go
@@ -1258,7 +1258,7 @@ var _ = Describe("PrefectServer controller", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(k8sClient.Get(ctx, name, prefectserver)).To(Succeed())
 
-				_, _, desiredMigrationJob := controllerReconciler.prefectServerDeployment(prefectserver)
+				_, _, desiredMigrationJob, _ := controllerReconciler.prefectServerDeployment(prefectserver)
 				migrateJob = &batchv1.Job{}
 				Eventually(func() error {
 					return k8sClient.Get(ctx, types.NamespacedName{
@@ -1447,7 +1447,7 @@ var _ = Describe("PrefectServer controller", func() {
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				_, _, desiredMigrationJob := controllerReconciler.prefectServerDeployment(prefectserver)
+				_, _, desiredMigrationJob, _ := controllerReconciler.prefectServerDeployment(prefectserver)
 				migrateJob = &batchv1.Job{}
 				Eventually(func() error {
 					return k8sClient.Get(ctx, types.NamespacedName{
@@ -1558,7 +1558,7 @@ var _ = Describe("PrefectServer controller", func() {
 				Expect(k8sClient.Get(ctx, name, prefectserver)).To(Succeed())
 
 				// Set the first migration Job to be complete
-				_, _, desiredMigrationJob := controllerReconciler.prefectServerDeployment(prefectserver)
+				_, _, desiredMigrationJob, _ := controllerReconciler.prefectServerDeployment(prefectserver)
 				migrateJob := &batchv1.Job{}
 				Eventually(func() error {
 					return k8sClient.Get(ctx, types.NamespacedName{
@@ -1581,7 +1581,7 @@ var _ = Describe("PrefectServer controller", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				// Set the second migration Job to be complete
-				_, _, desiredMigrationJob = controllerReconciler.prefectServerDeployment(prefectserver)
+				_, _, desiredMigrationJob, _ = controllerReconciler.prefectServerDeployment(prefectserver)
 				migrateJob = &batchv1.Job{}
 				Eventually(func() error {
 					return k8sClient.Get(ctx, types.NamespacedName{
@@ -1611,7 +1611,7 @@ var _ = Describe("PrefectServer controller", func() {
 			})
 
 			It("should create new migration Job with the new setting", func() {
-				_, _, desiredMigrationJob := controllerReconciler.prefectServerDeployment(prefectserver)
+				_, _, desiredMigrationJob, _ := controllerReconciler.prefectServerDeployment(prefectserver)
 				job := &batchv1.Job{}
 				Eventually(func() error {
 					return k8sClient.Get(ctx, types.NamespacedName{
@@ -1628,7 +1628,7 @@ var _ = Describe("PrefectServer controller", func() {
 			})
 
 			It("should do nothing if an active migration Job already exists", func() {
-				_, _, desiredMigrationJob := controllerReconciler.prefectServerDeployment(prefectserver)
+				_, _, desiredMigrationJob, _ := controllerReconciler.prefectServerDeployment(prefectserver)
 				migrateJob := &batchv1.Job{}
 				Eventually(func() error {
 					return k8sClient.Get(ctx, types.NamespacedName{
@@ -1829,6 +1829,122 @@ var _ = Describe("PrefectServer controller", func() {
 
 			Expect(k8sClient.Get(ctx, name, updatedPrefectServer)).To(Succeed())
 			Expect(updatedPrefectServer.Status.Ready).To(Equal(true))
+		})
+	})
+
+	Context("error handling scenarios", func() {
+		var (
+			ctx           context.Context
+			namespace     *corev1.Namespace
+			namespaceName string
+			name          types.NamespacedName
+			prefectserver *prefectiov1.PrefectServer
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			namespaceName = fmt.Sprintf("error-ns-%d", time.Now().UnixNano())
+
+			namespace = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: namespaceName},
+			}
+			Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
+
+			name = types.NamespacedName{
+				Namespace: namespaceName,
+				Name:      "prefect-server-test",
+			}
+
+			prefectserver = &prefectiov1.PrefectServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name.Name,
+					Namespace: namespaceName,
+				},
+				Spec: prefectiov1.PrefectServerSpec{
+					Image: ptr.To("prefecthq/prefect:2.11.0-python3.11"),
+				},
+			}
+		})
+
+		AfterEach(func() {
+			Expect(k8sClient.Delete(ctx, namespace)).To(Succeed())
+		})
+
+		It("should handle SetControllerReference errors when creating deployment specs", func() {
+			// Create a server without a proper scheme (simulates SetControllerReference error)
+			badReconciler := &PrefectServerReconciler{
+				Client: k8sClient,
+				Scheme: nil, // This will cause SetControllerReference to fail
+			}
+
+			// This test verifies that when the helper functions are called with an invalid scheme,
+			// errors are now properly handled and returned
+			_, _, _, err := badReconciler.prefectServerDeployment(prefectserver)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("scheme is nil, cannot set controller reference"))
+
+			// Test service creation with invalid scheme
+			_, err = badReconciler.prefectServerService(prefectserver)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("scheme is nil, cannot set controller reference"))
+		})
+
+		It("should handle SetControllerReference errors in PostgreSQL configurations", func() {
+			prefectserver.Spec.Postgres = &prefectiov1.PostgresConfiguration{
+				Host:     ptr.To("localhost"),
+				Port:     ptr.To(5432),
+				User:     ptr.To("prefect"),
+				Password: ptr.To("password"),
+				Database: ptr.To("prefect"),
+			}
+
+			badReconciler := &PrefectServerReconciler{
+				Client: k8sClient,
+				Scheme: nil, // This will cause SetControllerReference to fail
+			}
+
+			_, _, _, err := badReconciler.prefectServerDeployment(prefectserver)
+
+			// Verify that SetControllerReference error is now properly handled
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("scheme is nil, cannot set controller reference"))
+		})
+
+		It("should handle SetControllerReference errors in SQLite configurations", func() {
+			prefectserver.Spec.SQLite = &prefectiov1.SQLiteConfiguration{
+				StorageClassName: "standard",
+				Size:             resource.MustParse("1Gi"),
+			}
+
+			badReconciler := &PrefectServerReconciler{
+				Client: k8sClient,
+				Scheme: nil, // This will cause SetControllerReference to fail
+			}
+
+			_, _, _, err := badReconciler.prefectServerDeployment(prefectserver)
+
+			// Verify that SetControllerReference error is now properly handled
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("scheme is nil, cannot set controller reference"))
+		})
+
+		It("should demonstrate proper error propagation from helper functions", func() {
+			// Create server and attempt reconciliation
+			Expect(k8sClient.Create(ctx, prefectserver)).To(Succeed())
+
+			// Create a reconciler with invalid scheme to trigger SetControllerReference errors
+			badReconciler := &PrefectServerReconciler{
+				Client: k8sClient,
+				Scheme: nil,
+			}
+
+			// Now this reconciliation should fail early when the helper functions encounter
+			// SetControllerReference errors, rather than panicking later
+			_, err := badReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+
+			// The error should be properly propagated from the helper functions
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("scheme is nil, cannot set controller reference"))
 		})
 	})
 })


### PR DESCRIPTION
## Summary

This PR addresses the error handling gaps identified in issue #161 by implementing proper error handling for `SetControllerReference` calls in the PrefectServer controller.

### Problem

The helper functions `prefectServerDeployment()` and `prefectServerService()` were ignoring errors from `SetControllerReference` calls with TODO comments, which could lead to:
- Resources not being properly owned by their controllers
- Silent failures that are difficult to debug
- Potential runtime panics when invalid schemes are provided

### Solution

- **Modified function signatures** to return errors
- **Added nil scheme validation** to prevent panics before calling SetControllerReference
- **Implemented proper error propagation** from helper functions to callers
- **Added comprehensive error handling tests** to verify proper behavior

### Changes

- `prefectServerDeployment()` now returns `(deployment, pvc, job, error)` instead of `(deployment, pvc, job)`
- `prefectServerService()` now returns `(service, error)` instead of `service`
- All call sites updated to handle the new error return values
- Added 4 new test cases specifically for error handling scenarios

### Test Coverage

- **Baseline coverage**: 56.3%
- **Final coverage**: 56.3% (maintained)
- **All tests passing**: ✅

### Testing

The new tests verify that:
1. Helper functions properly return errors when scheme is nil
2. Error messages are descriptive and helpful
3. Errors are properly propagated through the reconciliation chain
4. Different configuration scenarios (ephemeral, SQLite, PostgreSQL) handle errors correctly

Fixes #161

## Test plan

- [x] All existing tests continue to pass
- [x] New error handling tests validate proper error propagation
- [x] Linters pass without issues
- [x] Coverage remains stable

🤖 Generated with [Claude Code](https://claude.ai/code)