### PR TITLE
Add prefect version to updatecli and bump prefect version to 3.4.14

### DIFF
--- a/.github/updatecli/manifest.yaml
+++ b/.github/updatecli/manifest.yaml
@@ -8,6 +8,16 @@ sources:
       versionFilter:
         kind: semver
     sourceid: common
+  prefect:
+    name: Prefect GitHub releases
+    kind: githubrelease
+    spec:
+      owner: PrefectHQ
+      repository: prefect
+      token: {{requiredEnv "GITHUB_TOKEN"}}
+      versionFilter:
+        kind: semver
+    sourceid: prefect
 conditions: {}
 targets:
   operator:
@@ -15,5 +25,13 @@ targets:
     kind: yaml
     spec:
       file: deploy/charts/prefect-operator/Chart.yaml
-      key: dependencies[0].version
+      key: $.dependencies[0].version
     sourceid: common
+  prefect-version:
+    name: update Prefect version constant
+    kind: file
+    spec:
+      file: api/v1/versioning.go
+      matchpattern: 'const DEFAULT_PREFECT_VERSION = "(.+)"'
+      replacepattern: 'const DEFAULT_PREFECT_VERSION = "{{ source "prefect" }}"'
+    sourceid: prefect

--- a/api/v1/versioning.go
+++ b/api/v1/versioning.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 )
 
-const DEFAULT_PREFECT_VERSION = "3.1.13"
+const DEFAULT_PREFECT_VERSION = "3.4.14"
 const DEFAULT_PREFECT_IMAGE = "prefecthq/prefect:" + DEFAULT_PREFECT_VERSION + "-python3.12"
 
 func VersionFromImage(image string) string {


### PR DESCRIPTION
This commit:
- adds Prefect GitHub releases as a source and add target for version bumping prefect version in `versioning.go` with `updatecli`
- bumps the prefect version to 3.4.14

You can test the updatecli with:
`updatecli diff --config .github/updatecli/manifest.yaml `

Closes https://github.com/PrefectHQ/prefect-operator/issues/185