### PR TITLE
create flow names consistent with CLI behavior

### DIFF
--- a/api/v1/prefectdeployment_types.go
+++ b/api/v1/prefectdeployment_types.go
@@ -17,6 +17,9 @@ limitations under the License.
 package v1
 
 import (
+	"fmt"
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -256,6 +259,18 @@ type PrefectDeploymentList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []PrefectDeployment `json:"items"`
+}
+
+// Here for future validation hooks.
+func (deployment *PrefectDeployment) Validate() error {
+	entryPoint := deployment.Spec.Deployment.Entrypoint
+
+	idx := strings.Index(entryPoint, ":")
+	if idx == -1 {
+		return fmt.Errorf("invalid entrypoint format (missing ':'): %s", entryPoint)
+	}
+
+	return nil
 }
 
 func init() {

--- a/internal/prefect/convert.go
+++ b/internal/prefect/convert.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	prefectiov1 "github.com/PrefectHQ/prefect-operator/api/v1"
@@ -179,8 +180,17 @@ func UpdateDeploymentStatus(k8sDeployment *prefectiov1.PrefectDeployment, prefec
 
 // GetFlowIDFromDeployment extracts or generates a flow ID for the deployment
 func GetFlowIDFromDeployment(ctx context.Context, client PrefectClient, k8sDeployment *prefectiov1.PrefectDeployment) (string, error) {
+	entryPoint := k8sDeployment.Spec.Deployment.Entrypoint
+
+	idx := strings.Index(entryPoint, ":")
+	if idx == -1 {
+		return "", fmt.Errorf("invalid entrypoint format (missing ':'): %s", entryPoint)
+	}
+
+	flowName := entryPoint[idx+1:]
+
 	flowSpec := &FlowSpec{
-		Name:   k8sDeployment.Name,
+		Name:   flowName,
 		Tags:   k8sDeployment.Spec.Deployment.Tags,
 		Labels: k8sDeployment.Spec.Deployment.Labels,
 	}


### PR DESCRIPTION
Updates flow naming logic to use the entrypoint function name as the flow name,
consistent with prefect CLI behavior

fixes #197
