### PR TITLE
Add ConfigMap permissions to operator ClusterRole

### DIFF
--- a/deploy/charts/prefect-operator/templates/rbac.yaml
+++ b/deploy/charts/prefect-operator/templates/rbac.yaml
@@ -15,6 +15,12 @@ rules:
       - list
       - watch
   - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [""]
     resources: ["events"]
     verbs:
         - create


### PR DESCRIPTION
## Summary

The operator needs to read ConfigMaps from any namespace where users deploy PrefectWorkPools or PrefectServers. This was missed when PR #194 added ConfigMap watching for base job templates - the controller calls `Watches(&corev1.ConfigMap{}, ...)` which requires cluster-wide list/watch permissions to sync the informer at startup.

Without these permissions, the operator fails with RBAC errors and enters CrashLoopBackOff.

The existing unit tests didn't catch this because envtest doesn't enforce RBAC - it's a simulated API server that grants all permissions. This kind of issue only surfaces when deploying to a real cluster. To confirm this, I deployed to a local cluster:

```
$ kubectl get pods -n prefect-system
NAME                                READY   STATUS    RESTARTS   AGE
prefect-operator-564fbfd7c9-kr5k6   1/1     Running   0          4m30s
```

Closes #234