### PR TITLE
chore: bump Go to 1.26 and apply go fix modernizations

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,8 +1,8 @@
 [tools]
 actionlint = "1.7.10"
 ginkgo = '2.25.2'
-golang = '1.24'
-golangci-lint = "2.8.0"
+golang = '1.26'
+golangci-lint = "2.9.0"
 "go:golang.org/x/tools/cmd/goimports" = "0.41.0"
 'go:fybrik.io/crdoc' = 'latest'
 helm = "4.1"
@@ -16,7 +16,6 @@ setup-envtest = "0.23.1"
 shellcheck = "0.11.0"
 yamllint = "1.38.0"
 yq = "4.52.2"
-go = "1.25"
 
 [settings]
 experimental = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24 AS builder
+FROM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/api/v1/prefectdeployment_types.go
+++ b/api/v1/prefectdeployment_types.go
@@ -265,8 +265,8 @@ type PrefectDeploymentList struct {
 func (deployment *PrefectDeployment) Validate() error {
 	entryPoint := deployment.Spec.Deployment.Entrypoint
 
-	idx := strings.Index(entryPoint, ":")
-	if idx == -1 {
+	found := strings.Contains(entryPoint, ":")
+	if !found {
 		return fmt.Errorf("invalid entrypoint format (missing ':'): %s", entryPoint)
 	}
 

--- a/api/v1/prefectdeployment_types_test.go
+++ b/api/v1/prefectdeployment_types_test.go
@@ -22,7 +22,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("PrefectDeployment type", func() {
@@ -34,9 +33,9 @@ var _ = Describe("PrefectDeployment type", func() {
 			},
 			Spec: PrefectDeploymentSpec{
 				Server: PrefectServerReference{
-					RemoteAPIURL: ptr.To("https://api.prefect.cloud/api/accounts/abc/workspaces/def"),
-					AccountID:    ptr.To("abc-123"),
-					WorkspaceID:  ptr.To("def-456"),
+					RemoteAPIURL: new("https://api.prefect.cloud/api/accounts/abc/workspaces/def"),
+					AccountID:    new("abc-123"),
+					WorkspaceID:  new("def-456"),
 					APIKey: &APIKeySpec{
 						ValueFrom: &corev1.EnvVarSource{
 							SecretKeyRef: &corev1.SecretKeySelector{
@@ -47,25 +46,25 @@ var _ = Describe("PrefectDeployment type", func() {
 					},
 				},
 				WorkPool: PrefectWorkPoolReference{
-					Namespace: ptr.To("default"),
+					Namespace: new("default"),
 					Name:      "kubernetes-work-pool",
-					WorkQueue: ptr.To("default"),
+					WorkQueue: new("default"),
 				},
 				Deployment: PrefectDeploymentConfiguration{
-					Description: ptr.To("Test deployment"),
+					Description: new("Test deployment"),
 					Tags:        []string{"test", "kubernetes"},
 					Labels: map[string]string{
 						"environment": "test",
 						"team":        "platform",
 					},
 					Entrypoint: "flows.py:my_flow",
-					Path:       ptr.To("/opt/prefect/flows"),
-					Paused:     ptr.To(false),
+					Path:       new("/opt/prefect/flows"),
+					Paused:     new(false),
 				},
 			},
 			Status: PrefectDeploymentStatus{
-				Id:     ptr.To("deployment-123"),
-				FlowId: ptr.To("flow-456"),
+				Id:     new("deployment-123"),
+				FlowId: new("flow-456"),
 				Ready:  true,
 			},
 		}
@@ -79,9 +78,9 @@ var _ = Describe("PrefectDeployment type", func() {
 	Context("PrefectServerReference", func() {
 		It("should support Prefect Cloud configuration", func() {
 			serverRef := PrefectServerReference{
-				RemoteAPIURL: ptr.To("https://api.prefect.cloud/api/accounts/abc/workspaces/def"),
-				AccountID:    ptr.To("abc-123"),
-				WorkspaceID:  ptr.To("def-456"),
+				RemoteAPIURL: new("https://api.prefect.cloud/api/accounts/abc/workspaces/def"),
+				AccountID:    new("abc-123"),
+				WorkspaceID:  new("def-456"),
 				APIKey: &APIKeySpec{
 					ValueFrom: &corev1.EnvVarSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
@@ -92,15 +91,15 @@ var _ = Describe("PrefectDeployment type", func() {
 				},
 			}
 
-			Expect(serverRef.RemoteAPIURL).To(Equal(ptr.To("https://api.prefect.cloud/api/accounts/abc/workspaces/def")))
-			Expect(serverRef.AccountID).To(Equal(ptr.To("abc-123")))
-			Expect(serverRef.WorkspaceID).To(Equal(ptr.To("def-456")))
+			Expect(serverRef.RemoteAPIURL).To(Equal(new("https://api.prefect.cloud/api/accounts/abc/workspaces/def")))
+			Expect(serverRef.AccountID).To(Equal(new("abc-123")))
+			Expect(serverRef.WorkspaceID).To(Equal(new("def-456")))
 			Expect(serverRef.APIKey).NotTo(BeNil())
 		})
 
 		It("should support self-hosted Prefect server configuration", func() {
 			serverRef := PrefectServerReference{
-				RemoteAPIURL: ptr.To("https://prefect.example.com/api"),
+				RemoteAPIURL: new("https://prefect.example.com/api"),
 				APIKey: &APIKeySpec{
 					ValueFrom: &corev1.EnvVarSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
@@ -111,7 +110,7 @@ var _ = Describe("PrefectDeployment type", func() {
 				},
 			}
 
-			Expect(serverRef.RemoteAPIURL).To(Equal(ptr.To("https://prefect.example.com/api")))
+			Expect(serverRef.RemoteAPIURL).To(Equal(new("https://prefect.example.com/api")))
 			Expect(serverRef.AccountID).To(BeNil())
 			Expect(serverRef.WorkspaceID).To(BeNil())
 			Expect(serverRef.APIKey).NotTo(BeNil())
@@ -121,32 +120,32 @@ var _ = Describe("PrefectDeployment type", func() {
 	Context("PrefectWorkPoolReference", func() {
 		It("should support namespaced work pool reference", func() {
 			workPoolRef := PrefectWorkPoolReference{
-				Namespace: ptr.To("prefect-system"),
+				Namespace: new("prefect-system"),
 				Name:      "kubernetes-work-pool",
-				WorkQueue: ptr.To("high-priority"),
+				WorkQueue: new("high-priority"),
 			}
 
-			Expect(workPoolRef.Namespace).To(Equal(ptr.To("prefect-system")))
+			Expect(workPoolRef.Namespace).To(Equal(new("prefect-system")))
 			Expect(workPoolRef.Name).To(Equal("kubernetes-work-pool"))
-			Expect(workPoolRef.WorkQueue).To(Equal(ptr.To("high-priority")))
+			Expect(workPoolRef.WorkQueue).To(Equal(new("high-priority")))
 		})
 
 		It("should support work pool reference without namespace", func() {
 			workPoolRef := PrefectWorkPoolReference{
 				Name:      "process-work-pool",
-				WorkQueue: ptr.To("default"),
+				WorkQueue: new("default"),
 			}
 
 			Expect(workPoolRef.Namespace).To(BeNil())
 			Expect(workPoolRef.Name).To(Equal("process-work-pool"))
-			Expect(workPoolRef.WorkQueue).To(Equal(ptr.To("default")))
+			Expect(workPoolRef.WorkQueue).To(Equal(new("default")))
 		})
 	})
 
 	Context("PrefectDeploymentConfiguration", func() {
 		It("should support basic deployment configuration", func() {
 			deploymentConfig := PrefectDeploymentConfiguration{
-				Description: ptr.To("My test flow deployment"),
+				Description: new("My test flow deployment"),
 				Tags:        []string{"test", "ci/cd", "production"},
 				Labels: map[string]string{
 					"environment": "production",
@@ -154,17 +153,17 @@ var _ = Describe("PrefectDeployment type", func() {
 					"version":     "1.0.0",
 				},
 				Entrypoint: "flows/etl.py:main_flow",
-				Path:       ptr.To("/opt/prefect/flows"),
-				Paused:     ptr.To(false),
+				Path:       new("/opt/prefect/flows"),
+				Paused:     new(false),
 			}
 
-			Expect(deploymentConfig.Description).To(Equal(ptr.To("My test flow deployment")))
+			Expect(deploymentConfig.Description).To(Equal(new("My test flow deployment")))
 			Expect(deploymentConfig.Tags).To(Equal([]string{"test", "ci/cd", "production"}))
 			Expect(deploymentConfig.Labels).To(HaveKeyWithValue("environment", "production"))
 			Expect(deploymentConfig.Labels).To(HaveKeyWithValue("team", "data-engineering"))
 			Expect(deploymentConfig.Entrypoint).To(Equal("flows/etl.py:main_flow"))
-			Expect(deploymentConfig.Path).To(Equal(ptr.To("/opt/prefect/flows")))
-			Expect(deploymentConfig.Paused).To(Equal(ptr.To(false)))
+			Expect(deploymentConfig.Path).To(Equal(new("/opt/prefect/flows")))
+			Expect(deploymentConfig.Paused).To(Equal(new(false)))
 		})
 
 		It("should support deployment with legacy nested schedules", func() {
@@ -174,27 +173,27 @@ var _ = Describe("PrefectDeployment type", func() {
 				Schedules: []PrefectSchedule{
 					{
 						Slug:             "daily-schedule",
-						Interval:         ptr.To(86400), // 24 hours in seconds
-						AnchorDate:       ptr.To("2024-01-01T00:00:00Z"),
-						Timezone:         ptr.To("UTC"),
-						Active:           ptr.To(true),
-						MaxScheduledRuns: ptr.To(10),
+						Interval:         new(86400), // 24 hours in seconds
+						AnchorDate:       new("2024-01-01T00:00:00Z"),
+						Timezone:         new("UTC"),
+						Active:           new(true),
+						MaxScheduledRuns: new(10),
 					},
 					{
 						Slug:       "hourly-schedule",
-						Interval:   ptr.To(3600), // 1 hour in seconds
-						AnchorDate: ptr.To("2024-01-01T00:00:00Z"),
-						Timezone:   ptr.To("UTC"),
-						Active:     ptr.To(false),
+						Interval:   new(3600), // 1 hour in seconds
+						AnchorDate: new("2024-01-01T00:00:00Z"),
+						Timezone:   new("UTC"),
+						Active:     new(false),
 					},
 				},
 			}
 
 			Expect(deploymentConfig.Schedules).To(HaveLen(2))
 			Expect(deploymentConfig.Schedules[0].Slug).To(Equal("daily-schedule"))
-			Expect(deploymentConfig.Schedules[0].Interval).To(Equal(ptr.To(86400)))
+			Expect(deploymentConfig.Schedules[0].Interval).To(Equal(new(86400)))
 			Expect(deploymentConfig.Schedules[1].Slug).To(Equal("hourly-schedule"))
-			Expect(deploymentConfig.Schedules[1].Active).To(Equal(ptr.To(false)))
+			Expect(deploymentConfig.Schedules[1].Active).To(Equal(new(false)))
 		})
 
 		It("should support deployment with flattened interval schedules", func() {
@@ -203,33 +202,33 @@ var _ = Describe("PrefectDeployment type", func() {
 				Schedules: []PrefectSchedule{
 					{
 						Slug:             "daily-interval",
-						Interval:         ptr.To(86400), // 24 hours in seconds
-						AnchorDate:       ptr.To("2024-01-01T00:00:00Z"),
-						Timezone:         ptr.To("UTC"),
-						Active:           ptr.To(true),
-						MaxScheduledRuns: ptr.To(10),
+						Interval:         new(86400), // 24 hours in seconds
+						AnchorDate:       new("2024-01-01T00:00:00Z"),
+						Timezone:         new("UTC"),
+						Active:           new(true),
+						MaxScheduledRuns: new(10),
 					},
 					{
 						Slug:       "hourly-interval",
-						Interval:   ptr.To(3600), // 1 hour in seconds
-						AnchorDate: ptr.To("2024-01-01T00:00:00Z"),
-						Timezone:   ptr.To("UTC"),
-						Active:     ptr.To(false),
+						Interval:   new(3600), // 1 hour in seconds
+						AnchorDate: new("2024-01-01T00:00:00Z"),
+						Timezone:   new("UTC"),
+						Active:     new(false),
 					},
 				},
 			}
 
 			Expect(deploymentConfig.Schedules).To(HaveLen(2))
 			Expect(deploymentConfig.Schedules[0].Slug).To(Equal("daily-interval"))
-			Expect(deploymentConfig.Schedules[0].Interval).To(Equal(ptr.To(86400)))
-			Expect(deploymentConfig.Schedules[0].AnchorDate).To(Equal(ptr.To("2024-01-01T00:00:00Z")))
-			Expect(deploymentConfig.Schedules[0].Timezone).To(Equal(ptr.To("UTC")))
-			Expect(deploymentConfig.Schedules[0].Active).To(Equal(ptr.To(true)))
-			Expect(deploymentConfig.Schedules[0].MaxScheduledRuns).To(Equal(ptr.To(10)))
+			Expect(deploymentConfig.Schedules[0].Interval).To(Equal(new(86400)))
+			Expect(deploymentConfig.Schedules[0].AnchorDate).To(Equal(new("2024-01-01T00:00:00Z")))
+			Expect(deploymentConfig.Schedules[0].Timezone).To(Equal(new("UTC")))
+			Expect(deploymentConfig.Schedules[0].Active).To(Equal(new(true)))
+			Expect(deploymentConfig.Schedules[0].MaxScheduledRuns).To(Equal(new(10)))
 
 			Expect(deploymentConfig.Schedules[1].Slug).To(Equal("hourly-interval"))
-			Expect(deploymentConfig.Schedules[1].Interval).To(Equal(ptr.To(3600)))
-			Expect(deploymentConfig.Schedules[1].Active).To(Equal(ptr.To(false)))
+			Expect(deploymentConfig.Schedules[1].Interval).To(Equal(new(3600)))
+			Expect(deploymentConfig.Schedules[1].Active).To(Equal(new(false)))
 		})
 
 		It("should support deployment with cron schedules", func() {
@@ -238,32 +237,32 @@ var _ = Describe("PrefectDeployment type", func() {
 				Schedules: []PrefectSchedule{
 					{
 						Slug:     "daily-9am",
-						Cron:     ptr.To("0 9 * * *"),
-						DayOr:    ptr.To(true),
-						Timezone: ptr.To("America/New_York"),
-						Active:   ptr.To(true),
+						Cron:     new("0 9 * * *"),
+						DayOr:    new(true),
+						Timezone: new("America/New_York"),
+						Active:   new(true),
 					},
 					{
 						Slug:             "every-5-minutes",
-						Cron:             ptr.To("*/5 * * * *"),
-						Timezone:         ptr.To("UTC"),
-						Active:           ptr.To(true),
-						MaxScheduledRuns: ptr.To(100),
+						Cron:             new("*/5 * * * *"),
+						Timezone:         new("UTC"),
+						Active:           new(true),
+						MaxScheduledRuns: new(100),
 					},
 				},
 			}
 
 			Expect(deploymentConfig.Schedules).To(HaveLen(2))
 			Expect(deploymentConfig.Schedules[0].Slug).To(Equal("daily-9am"))
-			Expect(deploymentConfig.Schedules[0].Cron).To(Equal(ptr.To("0 9 * * *")))
-			Expect(deploymentConfig.Schedules[0].DayOr).To(Equal(ptr.To(true)))
-			Expect(deploymentConfig.Schedules[0].Timezone).To(Equal(ptr.To("America/New_York")))
-			Expect(deploymentConfig.Schedules[0].Active).To(Equal(ptr.To(true)))
+			Expect(deploymentConfig.Schedules[0].Cron).To(Equal(new("0 9 * * *")))
+			Expect(deploymentConfig.Schedules[0].DayOr).To(Equal(new(true)))
+			Expect(deploymentConfig.Schedules[0].Timezone).To(Equal(new("America/New_York")))
+			Expect(deploymentConfig.Schedules[0].Active).To(Equal(new(true)))
 
 			Expect(deploymentConfig.Schedules[1].Slug).To(Equal("every-5-minutes"))
-			Expect(deploymentConfig.Schedules[1].Cron).To(Equal(ptr.To("*/5 * * * *")))
-			Expect(deploymentConfig.Schedules[1].Timezone).To(Equal(ptr.To("UTC")))
-			Expect(deploymentConfig.Schedules[1].MaxScheduledRuns).To(Equal(ptr.To(100)))
+			Expect(deploymentConfig.Schedules[1].Cron).To(Equal(new("*/5 * * * *")))
+			Expect(deploymentConfig.Schedules[1].Timezone).To(Equal(new("UTC")))
+			Expect(deploymentConfig.Schedules[1].MaxScheduledRuns).To(Equal(new(100)))
 		})
 
 		It("should support deployment with rrule schedules", func() {
@@ -272,30 +271,30 @@ var _ = Describe("PrefectDeployment type", func() {
 				Schedules: []PrefectSchedule{
 					{
 						Slug:     "weekly-monday",
-						RRule:    ptr.To("RRULE:FREQ=WEEKLY;BYDAY=MO"),
-						Timezone: ptr.To("UTC"),
-						Active:   ptr.To(true),
+						RRule:    new("RRULE:FREQ=WEEKLY;BYDAY=MO"),
+						Timezone: new("UTC"),
+						Active:   new(true),
 					},
 					{
 						Slug:             "monthly-first-friday",
-						RRule:            ptr.To("RRULE:FREQ=MONTHLY;BYDAY=1FR"),
-						Timezone:         ptr.To("America/Los_Angeles"),
-						Active:           ptr.To(true),
-						MaxScheduledRuns: ptr.To(12),
+						RRule:            new("RRULE:FREQ=MONTHLY;BYDAY=1FR"),
+						Timezone:         new("America/Los_Angeles"),
+						Active:           new(true),
+						MaxScheduledRuns: new(12),
 					},
 				},
 			}
 
 			Expect(deploymentConfig.Schedules).To(HaveLen(2))
 			Expect(deploymentConfig.Schedules[0].Slug).To(Equal("weekly-monday"))
-			Expect(deploymentConfig.Schedules[0].RRule).To(Equal(ptr.To("RRULE:FREQ=WEEKLY;BYDAY=MO")))
-			Expect(deploymentConfig.Schedules[0].Timezone).To(Equal(ptr.To("UTC")))
-			Expect(deploymentConfig.Schedules[0].Active).To(Equal(ptr.To(true)))
+			Expect(deploymentConfig.Schedules[0].RRule).To(Equal(new("RRULE:FREQ=WEEKLY;BYDAY=MO")))
+			Expect(deploymentConfig.Schedules[0].Timezone).To(Equal(new("UTC")))
+			Expect(deploymentConfig.Schedules[0].Active).To(Equal(new(true)))
 
 			Expect(deploymentConfig.Schedules[1].Slug).To(Equal("monthly-first-friday"))
-			Expect(deploymentConfig.Schedules[1].RRule).To(Equal(ptr.To("RRULE:FREQ=MONTHLY;BYDAY=1FR")))
-			Expect(deploymentConfig.Schedules[1].Timezone).To(Equal(ptr.To("America/Los_Angeles")))
-			Expect(deploymentConfig.Schedules[1].MaxScheduledRuns).To(Equal(ptr.To(12)))
+			Expect(deploymentConfig.Schedules[1].RRule).To(Equal(new("RRULE:FREQ=MONTHLY;BYDAY=1FR")))
+			Expect(deploymentConfig.Schedules[1].Timezone).To(Equal(new("America/Los_Angeles")))
+			Expect(deploymentConfig.Schedules[1].MaxScheduledRuns).To(Equal(new(12)))
 		})
 
 		It("should support deployment with mixed schedule types", func() {
@@ -304,22 +303,22 @@ var _ = Describe("PrefectDeployment type", func() {
 				Schedules: []PrefectSchedule{
 					{
 						Slug:       "hourly-interval",
-						Interval:   ptr.To(3600),
-						AnchorDate: ptr.To("2024-01-01T00:00:00Z"),
-						Timezone:   ptr.To("UTC"),
-						Active:     ptr.To(true),
+						Interval:   new(3600),
+						AnchorDate: new("2024-01-01T00:00:00Z"),
+						Timezone:   new("UTC"),
+						Active:     new(true),
 					},
 					{
 						Slug:     "daily-cron",
-						Cron:     ptr.To("0 9 * * *"),
-						Timezone: ptr.To("America/New_York"),
-						Active:   ptr.To(true),
+						Cron:     new("0 9 * * *"),
+						Timezone: new("America/New_York"),
+						Active:   new(true),
 					},
 					{
 						Slug:     "weekly-rrule",
-						RRule:    ptr.To("RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"),
-						Timezone: ptr.To("Europe/London"),
-						Active:   ptr.To(true),
+						RRule:    new("RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"),
+						Timezone: new("Europe/London"),
+						Active:   new(true),
 					},
 				},
 			}
@@ -327,17 +326,17 @@ var _ = Describe("PrefectDeployment type", func() {
 			Expect(deploymentConfig.Schedules).To(HaveLen(3))
 
 			// Interval schedule
-			Expect(deploymentConfig.Schedules[0].Interval).To(Equal(ptr.To(3600)))
+			Expect(deploymentConfig.Schedules[0].Interval).To(Equal(new(3600)))
 			Expect(deploymentConfig.Schedules[0].Cron).To(BeNil())
 			Expect(deploymentConfig.Schedules[0].RRule).To(BeNil())
 
 			// Cron schedule
-			Expect(deploymentConfig.Schedules[1].Cron).To(Equal(ptr.To("0 9 * * *")))
+			Expect(deploymentConfig.Schedules[1].Cron).To(Equal(new("0 9 * * *")))
 			Expect(deploymentConfig.Schedules[1].Interval).To(BeNil())
 			Expect(deploymentConfig.Schedules[1].RRule).To(BeNil())
 
 			// RRule schedule
-			Expect(deploymentConfig.Schedules[2].RRule).To(Equal(ptr.To("RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR")))
+			Expect(deploymentConfig.Schedules[2].RRule).To(Equal(new("RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR")))
 			Expect(deploymentConfig.Schedules[2].Interval).To(BeNil())
 			Expect(deploymentConfig.Schedules[2].Cron).To(BeNil())
 		})
@@ -345,36 +344,36 @@ var _ = Describe("PrefectDeployment type", func() {
 		It("should support deployment with concurrency limits", func() {
 			deploymentConfig := PrefectDeploymentConfiguration{
 				Entrypoint:       "flows.py:my_flow",
-				ConcurrencyLimit: ptr.To(5),
+				ConcurrencyLimit: new(5),
 				GlobalConcurrencyLimit: &PrefectGlobalConcurrencyLimit{
-					Active:             ptr.To(true),
+					Active:             new(true),
 					Name:               "global-etl-limit",
-					Limit:              ptr.To(10),
-					SlotDecayPerSecond: ptr.To("0.1"),
-					CollisionStrategy:  ptr.To("CANCEL_NEW"),
+					Limit:              new(10),
+					SlotDecayPerSecond: new("0.1"),
+					CollisionStrategy:  new("CANCEL_NEW"),
 				},
 			}
 
-			Expect(deploymentConfig.ConcurrencyLimit).To(Equal(ptr.To(5)))
+			Expect(deploymentConfig.ConcurrencyLimit).To(Equal(new(5)))
 			Expect(deploymentConfig.GlobalConcurrencyLimit).NotTo(BeNil())
 			Expect(deploymentConfig.GlobalConcurrencyLimit.Name).To(Equal("global-etl-limit"))
-			Expect(deploymentConfig.GlobalConcurrencyLimit.Limit).To(Equal(ptr.To(10)))
-			Expect(deploymentConfig.GlobalConcurrencyLimit.CollisionStrategy).To(Equal(ptr.To("CANCEL_NEW")))
-			Expect(deploymentConfig.GlobalConcurrencyLimit.SlotDecayPerSecond).To(Equal(ptr.To("0.1")))
+			Expect(deploymentConfig.GlobalConcurrencyLimit.Limit).To(Equal(new(10)))
+			Expect(deploymentConfig.GlobalConcurrencyLimit.CollisionStrategy).To(Equal(new("CANCEL_NEW")))
+			Expect(deploymentConfig.GlobalConcurrencyLimit.SlotDecayPerSecond).To(Equal(new("0.1")))
 		})
 
 		It("should support deployment with version info", func() {
 			deploymentConfig := PrefectDeploymentConfiguration{
 				Entrypoint: "flows.py:my_flow",
 				VersionInfo: &PrefectVersionInfo{
-					Type:    ptr.To("git"),
-					Version: ptr.To("v1.2.3"),
+					Type:    new("git"),
+					Version: new("v1.2.3"),
 				},
 			}
 
 			Expect(deploymentConfig.VersionInfo).NotTo(BeNil())
-			Expect(deploymentConfig.VersionInfo.Type).To(Equal(ptr.To("git")))
-			Expect(deploymentConfig.VersionInfo.Version).To(Equal(ptr.To("v1.2.3")))
+			Expect(deploymentConfig.VersionInfo.Type).To(Equal(new("git")))
+			Expect(deploymentConfig.VersionInfo.Version).To(Equal(new("v1.2.3")))
 		})
 
 		It("should support deployment with parameters and job variables", func() {
@@ -393,13 +392,13 @@ var _ = Describe("PrefectDeployment type", func() {
 				Parameters:             parameters,
 				JobVariables:           jobVariables,
 				ParameterOpenApiSchema: parameterSchema,
-				EnforceParameterSchema: ptr.To(true),
+				EnforceParameterSchema: new(true),
 			}
 
 			Expect(deploymentConfig.Parameters).To(Equal(parameters))
 			Expect(deploymentConfig.JobVariables).To(Equal(jobVariables))
 			Expect(deploymentConfig.ParameterOpenApiSchema).To(Equal(parameterSchema))
-			Expect(deploymentConfig.EnforceParameterSchema).To(Equal(ptr.To(true)))
+			Expect(deploymentConfig.EnforceParameterSchema).To(Equal(new(true)))
 		})
 
 		It("should support deployment with pull steps", func() {
@@ -422,15 +421,15 @@ var _ = Describe("PrefectDeployment type", func() {
 	Context("PrefectDeploymentStatus", func() {
 		It("should track deployment status correctly", func() {
 			status := PrefectDeploymentStatus{
-				Id:                 ptr.To("deployment-123"),
-				FlowId:             ptr.To("flow-456"),
+				Id:                 new("deployment-123"),
+				FlowId:             new("flow-456"),
 				Ready:              true,
 				SpecHash:           "abc123def456",
 				ObservedGeneration: 2,
 			}
 
-			Expect(status.Id).To(Equal(ptr.To("deployment-123")))
-			Expect(status.FlowId).To(Equal(ptr.To("flow-456")))
+			Expect(status.Id).To(Equal(new("deployment-123")))
+			Expect(status.FlowId).To(Equal(new("flow-456")))
 			Expect(status.Ready).To(BeTrue())
 			Expect(status.SpecHash).To(Equal("abc123def456"))
 			Expect(status.ObservedGeneration).To(Equal(int64(2)))

--- a/api/v1/prefectserver_types.go
+++ b/api/v1/prefectserver_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"maps"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
@@ -365,9 +366,7 @@ func (s *PrefectServer) ServerLabels() map[string]string {
 		"prefect.io/server": s.Name,
 		"app":               "prefect-server",
 	}
-	for k, v := range s.Spec.DeploymentLabels {
-		labels[k] = v
-	}
+	maps.Copy(labels, s.Spec.DeploymentLabels)
 	return labels
 }
 
@@ -375,9 +374,7 @@ func (s *PrefectServer) ServiceLabels() map[string]string {
 	labels := map[string]string{
 		"prefect.io/server": s.Name,
 	}
-	for k, v := range s.Spec.ServiceLabels {
-		labels[k] = v
-	}
+	maps.Copy(labels, s.Spec.ServiceLabels)
 	return labels
 }
 
@@ -385,9 +382,7 @@ func (s *PrefectServer) MigrationJobLabels() map[string]string {
 	labels := map[string]string{
 		"prefect.io/server": s.Name,
 	}
-	for k, v := range s.Spec.MigrationJobLabels {
-		labels[k] = v
-	}
+	maps.Copy(labels, s.Spec.MigrationJobLabels)
 	return labels
 }
 

--- a/api/v1/prefectserver_types_test.go
+++ b/api/v1/prefectserver_types_test.go
@@ -22,7 +22,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("PrefectServer type", func() {
@@ -32,8 +31,8 @@ var _ = Describe("PrefectServer type", func() {
 				Name: "test",
 			},
 			Spec: PrefectServerSpec{
-				Version: ptr.To("0.0.1"),
-				Image:   ptr.To("prefecthq/prefect:0.0.1"),
+				Version: new("0.0.1"),
+				Image:   new("prefecthq/prefect:0.0.1"),
 				SQLite: &SQLiteConfiguration{
 					StorageClassName: "standard",
 					Size:             resource.MustParse("1Gi"),
@@ -52,11 +51,11 @@ var _ = Describe("PrefectServer type", func() {
 			server := &PrefectServer{
 				Spec: PrefectServerSpec{
 					Postgres: &PostgresConfiguration{
-						Host:     ptr.To("postgres.example.com"),
-						Port:     ptr.To(5432),
-						User:     ptr.To("prefect"),
-						Password: ptr.To("secret123"),
-						Database: ptr.To("prefect"),
+						Host:     new("postgres.example.com"),
+						Port:     new(5432),
+						User:     new("prefect"),
+						Password: new("secret123"),
+						Database: new("prefect"),
 					},
 				},
 			}
@@ -241,16 +240,16 @@ var _ = Describe("PrefectServer type", func() {
 			server := &PrefectServer{
 				Spec: PrefectServerSpec{
 					Postgres: &PostgresConfiguration{
-						Host:     ptr.To("postgres.example.com"),
-						Port:     ptr.To(5432),
-						User:     ptr.To("prefect"),
-						Password: ptr.To("secret123"),
-						Database: ptr.To("prefect"),
+						Host:     new("postgres.example.com"),
+						Port:     new(5432),
+						User:     new("prefect"),
+						Password: new("secret123"),
+						Database: new("prefect"),
 					},
 					Redis: &RedisConfiguration{
-						Host:     ptr.To("redis.example.com"),
-						Port:     ptr.To(6379),
-						Database: ptr.To(0),
+						Host:     new("redis.example.com"),
+						Port:     new(6379),
+						Database: new(0),
 					},
 					Settings: []corev1.EnvVar{
 						{Name: "PREFECT_EXTRA_SETTING", Value: "extra-value"},
@@ -289,11 +288,11 @@ var _ = Describe("PrefectServer type", func() {
 			server := &PrefectServer{
 				Spec: PrefectServerSpec{
 					Redis: &RedisConfiguration{
-						Host:     ptr.To("redis.example.com"),
-						Port:     ptr.To(6379),
-						Database: ptr.To(0),
-						Username: ptr.To("prefect"),
-						Password: ptr.To("secret123"),
+						Host:     new("redis.example.com"),
+						Port:     new(6379),
+						Database: new(0),
+						Username: new("prefect"),
+						Password: new("secret123"),
 					},
 				},
 			}
@@ -410,9 +409,9 @@ var _ = Describe("PrefectServer type", func() {
 			server := &PrefectServer{
 				Spec: PrefectServerSpec{
 					Redis: &RedisConfiguration{
-						Host:     ptr.To("redis.example.com"),
-						Port:     ptr.To(6379),
-						Database: ptr.To(0),
+						Host:     new("redis.example.com"),
+						Port:     new(6379),
+						Database: new(0),
 					},
 				},
 			}
@@ -436,7 +435,7 @@ var _ = Describe("PrefectServer type", func() {
 			server := &PrefectServer{
 				Spec: PrefectServerSpec{
 					Redis: &RedisConfiguration{
-						Host: ptr.To("redis.example.com"),
+						Host: new("redis.example.com"),
 						// Only specifying host, other fields left empty
 					},
 				},
@@ -541,16 +540,16 @@ var _ = Describe("PrefectServer type", func() {
 			server := &PrefectServer{
 				Spec: PrefectServerSpec{
 					Postgres: &PostgresConfiguration{
-						Host:     ptr.To("postgres.example.com"),
-						Port:     ptr.To(5432),
-						User:     ptr.To("prefect"),
-						Password: ptr.To("secret123"),
-						Database: ptr.To("prefect"),
+						Host:     new("postgres.example.com"),
+						Port:     new(5432),
+						User:     new("prefect"),
+						Password: new("secret123"),
+						Database: new("prefect"),
 					},
 					Redis: &RedisConfiguration{
-						Host:     ptr.To("redis.example.com"),
-						Port:     ptr.To(6379),
-						Database: ptr.To(0),
+						Host:     new("redis.example.com"),
+						Port:     new(6379),
+						Database: new(0),
 					},
 					Settings: []corev1.EnvVar{
 						{Name: "PREFECT_EXTRA_SETTING", Value: "extra-value"},
@@ -634,7 +633,7 @@ var _ = Describe("PrefectServer type", func() {
 			It("should use empty string for IPv6/dual-stack when specified", func() {
 				server := &PrefectServer{
 					Spec: PrefectServerSpec{
-						Host: ptr.To(""),
+						Host: new(""),
 					},
 				}
 
@@ -645,7 +644,7 @@ var _ = Describe("PrefectServer type", func() {
 			It("should use custom host with ExtraArgs", func() {
 				server := &PrefectServer{
 					Spec: PrefectServerSpec{
-						Host:      ptr.To(""),
+						Host:      new(""),
 						ExtraArgs: []string{"--some-arg", "some-value"},
 					},
 				}
@@ -657,7 +656,7 @@ var _ = Describe("PrefectServer type", func() {
 			It("should use specific IPv4 address when specified", func() {
 				server := &PrefectServer{
 					Spec: PrefectServerSpec{
-						Host: ptr.To("127.0.0.1"),
+						Host: new("127.0.0.1"),
 					},
 				}
 

--- a/api/v1/prefectworkpool_types.go
+++ b/api/v1/prefectworkpool_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1
 
 import (
+	"maps"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -116,9 +118,7 @@ func (s *PrefectWorkPool) WorkerLabels() map[string]string {
 		"prefect.io/worker": s.Name,
 	}
 
-	for k, v := range s.Spec.DeploymentLabels {
-		labels[k] = v
-	}
+	maps.Copy(labels, s.Spec.DeploymentLabels)
 
 	return labels
 }

--- a/api/v1/prefectworkpool_types_test.go
+++ b/api/v1/prefectworkpool_types_test.go
@@ -19,7 +19,6 @@ package v1
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/ptr"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -31,8 +30,8 @@ var _ = Describe("PrefectWorkPool type", func() {
 				Name: "test",
 			},
 			Spec: PrefectWorkPoolSpec{
-				Version: ptr.To("0.0.1"),
-				Image:   ptr.To("prefecthq/prefect:0.0.1"),
+				Version: new("0.0.1"),
+				Image:   new("prefecthq/prefect:0.0.1"),
 				Server: PrefectServerReference{
 					Namespace: "default",
 					Name:      "prefect",

--- a/api/v1/server_reference_test.go
+++ b/api/v1/server_reference_test.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -59,7 +58,7 @@ var _ = Describe("PrefectServerReference", func() {
 		It("Should return direct value when APIKey.Value is set", func() {
 			serverRef := &PrefectServerReference{
 				APIKey: &APIKeySpec{
-					Value: ptr.To("direct-api-key-value"),
+					Value: new("direct-api-key-value"),
 				},
 			}
 
@@ -234,7 +233,7 @@ var _ = Describe("PrefectServerReference", func() {
 	Context("GetAPIURL method", func() {
 		It("Should return remote API URL when RemoteAPIURL is set", func() {
 			serverRef := &PrefectServerReference{
-				RemoteAPIURL: ptr.To("https://api.prefect.io"),
+				RemoteAPIURL: new("https://api.prefect.io"),
 			}
 
 			apiURL := serverRef.GetAPIURL("test-namespace")
@@ -243,7 +242,7 @@ var _ = Describe("PrefectServerReference", func() {
 
 		It("Should append /api to remote URL if not present", func() {
 			serverRef := &PrefectServerReference{
-				RemoteAPIURL: ptr.To("https://custom-server.com"),
+				RemoteAPIURL: new("https://custom-server.com"),
 			}
 
 			apiURL := serverRef.GetAPIURL("test-namespace")
@@ -252,7 +251,7 @@ var _ = Describe("PrefectServerReference", func() {
 
 		It("Should not double-append /api to remote URL", func() {
 			serverRef := &PrefectServerReference{
-				RemoteAPIURL: ptr.To("https://custom-server.com/api"),
+				RemoteAPIURL: new("https://custom-server.com/api"),
 			}
 
 			apiURL := serverRef.GetAPIURL("test-namespace")
@@ -261,9 +260,9 @@ var _ = Describe("PrefectServerReference", func() {
 
 		It("Should add Prefect Cloud workspace path when AccountID and WorkspaceID are set", func() {
 			serverRef := &PrefectServerReference{
-				RemoteAPIURL: ptr.To("https://api.prefect.cloud"),
-				AccountID:    ptr.To("account-123"),
-				WorkspaceID:  ptr.To("workspace-456"),
+				RemoteAPIURL: new("https://api.prefect.cloud"),
+				AccountID:    new("account-123"),
+				WorkspaceID:  new("workspace-456"),
 			}
 
 			apiURL := serverRef.GetAPIURL("test-namespace")
@@ -298,7 +297,7 @@ var _ = Describe("PrefectServerReference", func() {
 
 		It("Should prioritize RemoteAPIURL over in-cluster Name", func() {
 			serverRef := &PrefectServerReference{
-				RemoteAPIURL: ptr.To("https://external.prefect.io"),
+				RemoteAPIURL: new("https://external.prefect.io"),
 				Name:         "prefect-server",
 				Namespace:    "prefect-system",
 			}
@@ -311,7 +310,7 @@ var _ = Describe("PrefectServerReference", func() {
 	Context("Helper methods", func() {
 		It("Should correctly identify remote server references", func() {
 			serverRef := &PrefectServerReference{
-				RemoteAPIURL: ptr.To("https://api.prefect.io"),
+				RemoteAPIURL: new("https://api.prefect.io"),
 			}
 
 			Expect(serverRef.IsRemote()).To(BeTrue())
@@ -330,9 +329,9 @@ var _ = Describe("PrefectServerReference", func() {
 
 		It("Should correctly identify Prefect Cloud configuration", func() {
 			serverRef := &PrefectServerReference{
-				RemoteAPIURL: ptr.To("https://api.prefect.cloud"),
-				AccountID:    ptr.To("account-123"),
-				WorkspaceID:  ptr.To("workspace-456"),
+				RemoteAPIURL: new("https://api.prefect.cloud"),
+				AccountID:    new("account-123"),
+				WorkspaceID:  new("workspace-456"),
 			}
 
 			Expect(serverRef.IsPrefectCloud()).To(BeTrue())
@@ -340,8 +339,8 @@ var _ = Describe("PrefectServerReference", func() {
 
 		It("Should not identify as Prefect Cloud when AccountID is missing", func() {
 			serverRef := &PrefectServerReference{
-				RemoteAPIURL: ptr.To("https://api.prefect.cloud"),
-				WorkspaceID:  ptr.To("workspace-456"),
+				RemoteAPIURL: new("https://api.prefect.cloud"),
+				WorkspaceID:  new("workspace-456"),
 			}
 
 			Expect(serverRef.IsPrefectCloud()).To(BeFalse())
@@ -349,8 +348,8 @@ var _ = Describe("PrefectServerReference", func() {
 
 		It("Should not identify as Prefect Cloud when WorkspaceID is missing", func() {
 			serverRef := &PrefectServerReference{
-				RemoteAPIURL: ptr.To("https://api.prefect.cloud"),
-				AccountID:    ptr.To("account-123"),
+				RemoteAPIURL: new("https://api.prefect.cloud"),
+				AccountID:    new("account-123"),
 			}
 
 			Expect(serverRef.IsPrefectCloud()).To(BeFalse())
@@ -358,9 +357,9 @@ var _ = Describe("PrefectServerReference", func() {
 
 		It("Should not identify as Prefect Cloud when AccountID is empty", func() {
 			serverRef := &PrefectServerReference{
-				RemoteAPIURL: ptr.To("https://api.prefect.cloud"),
-				AccountID:    ptr.To(""),
-				WorkspaceID:  ptr.To("workspace-456"),
+				RemoteAPIURL: new("https://api.prefect.cloud"),
+				AccountID:    new(""),
+				WorkspaceID:  new("workspace-456"),
 			}
 
 			Expect(serverRef.IsPrefectCloud()).To(BeFalse())
@@ -368,9 +367,9 @@ var _ = Describe("PrefectServerReference", func() {
 
 		It("Should not identify as Prefect Cloud when WorkspaceID is empty", func() {
 			serverRef := &PrefectServerReference{
-				RemoteAPIURL: ptr.To("https://api.prefect.cloud"),
-				AccountID:    ptr.To("account-123"),
-				WorkspaceID:  ptr.To(""),
+				RemoteAPIURL: new("https://api.prefect.cloud"),
+				AccountID:    new("account-123"),
+				WorkspaceID:  new(""),
 			}
 
 			Expect(serverRef.IsPrefectCloud()).To(BeFalse())
@@ -378,7 +377,7 @@ var _ = Describe("PrefectServerReference", func() {
 
 		It("Should handle both remote and in-cluster configurations simultaneously", func() {
 			serverRef := &PrefectServerReference{
-				RemoteAPIURL: ptr.To("https://api.prefect.io"),
+				RemoteAPIURL: new("https://api.prefect.io"),
 				Name:         "prefect-server",
 				Namespace:    "prefect-system",
 			}
@@ -389,7 +388,7 @@ var _ = Describe("PrefectServerReference", func() {
 
 		It("Should handle empty RemoteAPIURL pointer", func() {
 			serverRef := &PrefectServerReference{
-				RemoteAPIURL: ptr.To(""),
+				RemoteAPIURL: new(""),
 				Name:         "prefect-server",
 			}
 
@@ -414,9 +413,9 @@ var _ = Describe("PrefectServerReference", func() {
 
 			// Create a server reference with Secret-based API key
 			serverRef := &PrefectServerReference{
-				RemoteAPIURL: ptr.To("https://api.prefect.cloud"),
-				AccountID:    ptr.To("account-123"),
-				WorkspaceID:  ptr.To("workspace-456"),
+				RemoteAPIURL: new("https://api.prefect.cloud"),
+				AccountID:    new("account-123"),
+				WorkspaceID:  new("workspace-456"),
 				APIKey: &APIKeySpec{
 					ValueFrom: &corev1.EnvVarSource{
 						SecretKeyRef: &corev1.SecretKeySelector{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -179,7 +179,7 @@ func getWatchNamespaces() map[string]cache.Config {
 	}
 
 	namespacesToWatch := make(map[string]cache.Config)
-	for _, ns := range strings.Split(namespaces, ",") {
+	for ns := range strings.SplitSeq(namespaces, ",") {
 		namespacesToWatch[ns] = cache.Config{}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	k8s.io/api v0.34.2
 	k8s.io/apimachinery v0.34.2
 	k8s.io/client-go v0.34.2
-	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	sigs.k8s.io/controller-runtime v0.22.4
 )
 
@@ -70,6 +69,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.34.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
+	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/PrefectHQ/prefect-operator
 
-go 1.24.2
+go 1.26
 
 require (
 	dario.cat/mergo v1.0.2

--- a/internal/controller/prefectdeployment_controller_test.go
+++ b/internal/controller/prefectdeployment_controller_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -85,9 +84,9 @@ var _ = Describe("PrefectDeployment controller", func() {
 			},
 			Spec: prefectiov1.PrefectDeploymentSpec{
 				Server: prefectiov1.PrefectServerReference{
-					RemoteAPIURL: ptr.To("https://api.prefect.cloud/api/accounts/abc/workspaces/def"),
-					AccountID:    ptr.To("abc-123"),
-					WorkspaceID:  ptr.To("def-456"),
+					RemoteAPIURL: new("https://api.prefect.cloud/api/accounts/abc/workspaces/def"),
+					AccountID:    new("abc-123"),
+					WorkspaceID:  new("def-456"),
 					APIKey: &prefectiov1.APIKeySpec{
 						ValueFrom: &corev1.EnvVarSource{
 							SecretKeyRef: &corev1.SecretKeySelector{
@@ -99,14 +98,14 @@ var _ = Describe("PrefectDeployment controller", func() {
 				},
 				WorkPool: prefectiov1.PrefectWorkPoolReference{
 					Name:      "kubernetes-work-pool",
-					WorkQueue: ptr.To("default"),
+					WorkQueue: new("default"),
 				},
 				Deployment: prefectiov1.PrefectDeploymentConfiguration{
-					Description: ptr.To("Test deployment"),
+					Description: new("Test deployment"),
 					Tags:        []string{"test", "kubernetes"},
 					Entrypoint:  "flows.py:my_flow",
-					Path:        ptr.To("/opt/prefect/flows"),
-					Paused:      ptr.To(false),
+					Path:        new("/opt/prefect/flows"),
+					Paused:      new(false),
 				},
 			},
 		}
@@ -255,7 +254,7 @@ var _ = Describe("PrefectDeployment controller", func() {
 
 		It("Should detect spec changes and trigger sync", func() {
 			By("Updating the deployment spec")
-			prefectDeployment.Spec.Deployment.Description = ptr.To("Updated description")
+			prefectDeployment.Spec.Deployment.Description = new("Updated description")
 			Expect(k8sClient.Update(ctx, prefectDeployment)).To(Succeed())
 
 			By("Reconciling after the change")
@@ -307,7 +306,7 @@ var _ = Describe("PrefectDeployment controller", func() {
 			Expect(needsSync).To(BeTrue(), "should need sync for new deployment")
 
 			By("Testing needsSync for spec changes")
-			deployment.Status.Id = ptr.To("existing-id")
+			deployment.Status.Id = new("existing-id")
 			deployment.Status.SpecHash = "old-hash"
 			deployment.Status.ObservedGeneration = 1
 			deployment.Generation = 1
@@ -418,7 +417,7 @@ var _ = Describe("PrefectDeployment controller", func() {
 			By("Testing GetAPIKey with direct value")
 			serverRef := &prefectiov1.PrefectServerReference{
 				APIKey: &prefectiov1.APIKeySpec{
-					Value: ptr.To("direct-api-key-value"),
+					Value: new("direct-api-key-value"),
 				},
 			}
 
@@ -568,9 +567,9 @@ var _ = Describe("PrefectDeployment controller", func() {
 				},
 				Spec: prefectiov1.PrefectDeploymentSpec{
 					Server: prefectiov1.PrefectServerReference{
-						RemoteAPIURL: ptr.To("https://api.prefect.cloud/api/accounts/abc/workspaces/def"),
+						RemoteAPIURL: new("https://api.prefect.cloud/api/accounts/abc/workspaces/def"),
 						APIKey: &prefectiov1.APIKeySpec{
-							Value: ptr.To("test-key"),
+							Value: new("test-key"),
 						},
 					},
 					WorkPool: prefectiov1.PrefectWorkPoolReference{
@@ -686,9 +685,9 @@ var _ = Describe("PrefectDeployment controller", func() {
 				},
 				Spec: prefectiov1.PrefectDeploymentSpec{
 					Server: prefectiov1.PrefectServerReference{
-						RemoteAPIURL: ptr.To("https://api.prefect.cloud/api/accounts/abc/workspaces/def"),
+						RemoteAPIURL: new("https://api.prefect.cloud/api/accounts/abc/workspaces/def"),
 						APIKey: &prefectiov1.APIKeySpec{
-							Value: ptr.To("test-key"),
+							Value: new("test-key"),
 						},
 					},
 					WorkPool: prefectiov1.PrefectWorkPoolReference{
@@ -742,9 +741,9 @@ var _ = Describe("PrefectDeployment controller", func() {
 				},
 				Spec: prefectiov1.PrefectDeploymentSpec{
 					Server: prefectiov1.PrefectServerReference{
-						RemoteAPIURL: ptr.To("https://api.prefect.cloud/api/accounts/abc/workspaces/def"),
+						RemoteAPIURL: new("https://api.prefect.cloud/api/accounts/abc/workspaces/def"),
 						APIKey: &prefectiov1.APIKeySpec{
-							Value: ptr.To("test-key"),
+							Value: new("test-key"),
 						},
 					},
 					WorkPool: prefectiov1.PrefectWorkPoolReference{
@@ -755,8 +754,8 @@ var _ = Describe("PrefectDeployment controller", func() {
 						Schedules: []prefectiov1.PrefectSchedule{
 							{
 								Slug:       "invalid-schedule",
-								Interval:   ptr.To(3600),
-								AnchorDate: ptr.To("invalid-date-format"),
+								Interval:   new(3600),
+								AnchorDate: new("invalid-date-format"),
 							},
 						},
 					},
@@ -799,9 +798,9 @@ var _ = Describe("PrefectDeployment controller", func() {
 				},
 				Spec: prefectiov1.PrefectDeploymentSpec{
 					Server: prefectiov1.PrefectServerReference{
-						RemoteAPIURL: ptr.To("https://api.prefect.cloud/api/accounts/abc/workspaces/def"),
+						RemoteAPIURL: new("https://api.prefect.cloud/api/accounts/abc/workspaces/def"),
 						APIKey: &prefectiov1.APIKeySpec{
-							Value: ptr.To("test-key"),
+							Value: new("test-key"),
 						},
 					},
 					WorkPool: prefectiov1.PrefectWorkPoolReference{

--- a/internal/controller/prefectserver_controller.go
+++ b/internal/controller/prefectserver_controller.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -346,7 +345,7 @@ func (r *PrefectServerReconciler) prefectServerDeployment(server *prefectiov1.Pr
 
 func (r *PrefectServerReconciler) ephemeralDeploymentSpec(server *prefectiov1.PrefectServer) appsv1.DeploymentSpec {
 	return appsv1.DeploymentSpec{
-		Replicas: ptr.To(int32(1)),
+		Replicas: new(int32(1)),
 		Strategy: appsv1.DeploymentStrategy{
 			Type: appsv1.RollingUpdateDeploymentStrategyType,
 		},
@@ -428,7 +427,7 @@ func (r *PrefectServerReconciler) sqlitePersistentVolumeClaim(server *prefectiov
 
 func (r *PrefectServerReconciler) sqliteDeploymentSpec(server *prefectiov1.PrefectServer, pvc *corev1.PersistentVolumeClaim) appsv1.DeploymentSpec {
 	return appsv1.DeploymentSpec{
-		Replicas: ptr.To(int32(1)),
+		Replicas: new(int32(1)),
 		Strategy: appsv1.DeploymentStrategy{
 			Type: appsv1.RecreateDeploymentStrategyType,
 		},
@@ -491,7 +490,7 @@ func (r *PrefectServerReconciler) sqliteDeploymentSpec(server *prefectiov1.Prefe
 
 func (r *PrefectServerReconciler) postgresDeploymentSpec(server *prefectiov1.PrefectServer) appsv1.DeploymentSpec {
 	return appsv1.DeploymentSpec{
-		Replicas: ptr.To(int32(1)),
+		Replicas: new(int32(1)),
 		Strategy: appsv1.DeploymentStrategy{
 			Type: appsv1.RollingUpdateDeploymentStrategyType,
 		},
@@ -541,7 +540,7 @@ func (r *PrefectServerReconciler) postgresDeploymentSpec(server *prefectiov1.Pre
 
 func (r *PrefectServerReconciler) postgresMigrationJob(server *prefectiov1.PrefectServer) *batchv1.Job {
 	jobSpec := batchv1.JobSpec{
-		TTLSecondsAfterFinished: ptr.To(int32(60 * 60)), // 1 hour
+		TTLSecondsAfterFinished: new(int32(60 * 60)), // 1 hour
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: server.MigrationJobLabels(),

--- a/internal/controller/prefectserver_controller_test.go
+++ b/internal/controller/prefectserver_controller_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -87,7 +86,7 @@ var _ = Describe("PrefectServer controller", func() {
 					Name:      "prefect-on-anything",
 				},
 				Spec: prefectiov1.PrefectServerSpec{
-					Image: ptr.To("prefecthq/prefect:custom-prefect-image"),
+					Image: new("prefecthq/prefect:custom-prefect-image"),
 				},
 			}
 			Expect(k8sClient.Create(ctx, prefectserver)).To(Succeed())
@@ -270,8 +269,8 @@ var _ = Describe("PrefectServer controller", func() {
 							Kind:               "PrefectServer",
 							Name:               "prefect-on-anything",
 							UID:                prefectserver.UID,
-							Controller:         ptr.To(true),
-							BlockOwnerDeletion: ptr.To(true),
+							Controller:         new(true),
+							BlockOwnerDeletion: new(true),
 						},
 					))
 				})
@@ -397,8 +396,8 @@ var _ = Describe("PrefectServer controller", func() {
 							Kind:               "PrefectServer",
 							Name:               "prefect-on-anything",
 							UID:                prefectserver.UID,
-							Controller:         ptr.To(true),
-							BlockOwnerDeletion: ptr.To(true),
+							Controller:         new(true),
+							BlockOwnerDeletion: new(true),
 						},
 					))
 				})
@@ -657,7 +656,7 @@ var _ = Describe("PrefectServer controller", func() {
 						Name:      "prefect-ipv6-server",
 					},
 					Spec: prefectiov1.PrefectServerSpec{
-						Host: ptr.To(""),
+						Host: new(""),
 					},
 				}
 				Expect(k8sClient.Create(ctx, prefectserver)).To(Succeed())
@@ -1262,11 +1261,11 @@ var _ = Describe("PrefectServer controller", func() {
 					},
 					Spec: prefectiov1.PrefectServerSpec{
 						Postgres: &prefectiov1.PostgresConfiguration{
-							Host:     ptr.To("some-postgres-server"),
-							Port:     ptr.To(15432),
-							User:     ptr.To("a-prefect-user"),
-							Password: ptr.To("this-is-a-bad-idea"),
-							Database: ptr.To("some-prefect"),
+							Host:     new("some-postgres-server"),
+							Port:     new(15432),
+							User:     new("a-prefect-user"),
+							Password: new("this-is-a-bad-idea"),
+							Database: new("some-prefect"),
 						},
 						DeploymentLabels: map[string]string{
 							"some":    "additional-label",
@@ -1391,8 +1390,8 @@ var _ = Describe("PrefectServer controller", func() {
 							Kind:               "PrefectServer",
 							Name:               "prefect-on-postgres",
 							UID:                prefectserver.UID,
-							Controller:         ptr.To(true),
-							BlockOwnerDeletion: ptr.To(true),
+							Controller:         new(true),
+							BlockOwnerDeletion: new(true),
 						},
 					))
 				})
@@ -1571,11 +1570,11 @@ var _ = Describe("PrefectServer controller", func() {
 					},
 					Spec: prefectiov1.PrefectServerSpec{
 						Postgres: &prefectiov1.PostgresConfiguration{
-							Host:     ptr.To("some-postgres-server"),
-							Port:     ptr.To(15432),
-							User:     ptr.To("a-prefect-user"),
-							Password: ptr.To("this-is-a-bad-idea"),
-							Database: ptr.To("some-prefect"),
+							Host:     new("some-postgres-server"),
+							Port:     new(15432),
+							User:     new("a-prefect-user"),
+							Password: new("this-is-a-bad-idea"),
+							Database: new("some-prefect"),
 						},
 					},
 				}
@@ -1707,11 +1706,11 @@ var _ = Describe("PrefectServer controller", func() {
 					},
 					Spec: prefectiov1.PrefectServerSpec{
 						Postgres: &prefectiov1.PostgresConfiguration{
-							Host:     ptr.To("some-postgres-server"),
-							Port:     ptr.To(15432),
-							User:     ptr.To("a-prefect-user"),
-							Password: ptr.To("this-is-a-bad-idea"),
-							Database: ptr.To("some-prefect"),
+							Host:     new("some-postgres-server"),
+							Port:     new(15432),
+							User:     new("a-prefect-user"),
+							Password: new("this-is-a-bad-idea"),
+							Database: new("some-prefect"),
 						},
 					},
 				}
@@ -1897,7 +1896,7 @@ var _ = Describe("PrefectServer controller", func() {
 					Namespace: namespaceName,
 				},
 				Spec: prefectiov1.PrefectServerSpec{
-					Image: ptr.To("prefecthq/prefect:2.11.0-python3.11"),
+					Image: new("prefecthq/prefect:2.11.0-python3.11"),
 				},
 			}
 		})
@@ -1927,11 +1926,11 @@ var _ = Describe("PrefectServer controller", func() {
 
 		It("should handle SetControllerReference errors in PostgreSQL configurations", func() {
 			prefectserver.Spec.Postgres = &prefectiov1.PostgresConfiguration{
-				Host:     ptr.To("localhost"),
-				Port:     ptr.To(5432),
-				User:     ptr.To("prefect"),
-				Password: ptr.To("password"),
-				Database: ptr.To("prefect"),
+				Host:     new("localhost"),
+				Port:     new(5432),
+				User:     new("prefect"),
+				Password: new("password"),
+				Database: new("prefect"),
 			}
 
 			badReconciler := &PrefectServerReconciler{

--- a/internal/controller/prefectworkpool_controller_test.go
+++ b/internal/controller/prefectworkpool_controller_test.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -51,7 +50,7 @@ var _ = Describe("PrefectWorkPool Controller", func() {
 		prefectWorkPool     *prefectiov1.PrefectWorkPool
 		reconciler          *PrefectWorkPoolReconciler
 		mockClient          *prefect.MockClient
-		baseJobTemplate     map[string]interface{}
+		baseJobTemplate     map[string]any
 		baseJobTemplateJson []byte
 	)
 
@@ -78,9 +77,9 @@ var _ = Describe("PrefectWorkPool Controller", func() {
 			PrefectClient: mockClient,
 		}
 
-		baseJobTemplate = map[string]interface{}{
+		baseJobTemplate = map[string]any{
 			"foo": "bar",
-			"baz": []interface{}{"qux", "quux"},
+			"baz": []any{"qux", "quux"},
 		}
 
 		var err error
@@ -114,7 +113,7 @@ var _ = Describe("PrefectWorkPool Controller", func() {
 				Namespace: name.Namespace,
 			},
 			Spec: prefectiov1.PrefectWorkPoolSpec{
-				Image: ptr.To("prefecthq/prefect:custom-prefect-image"),
+				Image: new("prefecthq/prefect:custom-prefect-image"),
 			},
 		}
 		Expect(k8sClient.Create(ctx, prefectWorkPool)).To(Succeed())
@@ -148,7 +147,7 @@ var _ = Describe("PrefectWorkPool Controller", func() {
 				Namespace: name.Namespace,
 			},
 			Spec: prefectiov1.PrefectWorkPoolSpec{
-				Version: ptr.To("3.3.3.3.3.3.3.3"),
+				Version: new("3.3.3.3.3.3.3.3"),
 			},
 		}
 		Expect(k8sClient.Create(ctx, prefectWorkPool)).To(Succeed())
@@ -185,7 +184,7 @@ var _ = Describe("PrefectWorkPool Controller", func() {
 					Name:      name.Name,
 				},
 				Spec: prefectiov1.PrefectWorkPoolSpec{
-					Version: ptr.To("3.0.0"),
+					Version: new("3.0.0"),
 					Type:    "kubernetes",
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
@@ -354,8 +353,8 @@ var _ = Describe("PrefectWorkPool Controller", func() {
 						Kind:               "PrefectWorkPool",
 						Name:               name.Name,
 						UID:                prefectWorkPool.UID,
-						Controller:         ptr.To(true),
-						BlockOwnerDeletion: ptr.To(true),
+						Controller:         new(true),
+						BlockOwnerDeletion: new(true),
 					},
 				))
 			})
@@ -744,7 +743,7 @@ var _ = Describe("PrefectWorkPool Controller", func() {
 				Server: prefectiov1.PrefectServerReference{
 					Name:         "test-server",
 					Namespace:    name.Namespace,
-					RemoteAPIURL: ptr.To("https://some-server.example.com/api"),
+					RemoteAPIURL: new("https://some-server.example.com/api"),
 				},
 			},
 		}
@@ -785,7 +784,7 @@ var _ = Describe("PrefectWorkPool Controller", func() {
 				Server: prefectiov1.PrefectServerReference{
 					Name:         "test-server",
 					Namespace:    name.Namespace,
-					RemoteAPIURL: ptr.To("https://some-server.example.com"),
+					RemoteAPIURL: new("https://some-server.example.com"),
 				},
 			},
 		}
@@ -826,9 +825,9 @@ var _ = Describe("PrefectWorkPool Controller", func() {
 				Server: prefectiov1.PrefectServerReference{
 					Name:         "test-server",
 					Namespace:    name.Namespace,
-					RemoteAPIURL: ptr.To("https://remote.prefect.cloud/api"),
+					RemoteAPIURL: new("https://remote.prefect.cloud/api"),
 					APIKey: &prefectiov1.APIKeySpec{
-						Value: ptr.To("test-api-key"),
+						Value: new("test-api-key"),
 					},
 				},
 			},
@@ -874,7 +873,7 @@ var _ = Describe("PrefectWorkPool Controller", func() {
 				Server: prefectiov1.PrefectServerReference{
 					Name:         "test-server",
 					Namespace:    name.Namespace,
-					RemoteAPIURL: ptr.To("https://remote.prefect.cloud"),
+					RemoteAPIURL: new("https://remote.prefect.cloud"),
 					APIKey: &prefectiov1.APIKeySpec{
 						ValueFrom: &corev1.EnvVarSource{
 							SecretKeyRef: &corev1.SecretKeySelector{
@@ -937,9 +936,9 @@ var _ = Describe("PrefectWorkPool Controller", func() {
 			},
 			Spec: prefectiov1.PrefectWorkPoolSpec{
 				Server: prefectiov1.PrefectServerReference{
-					RemoteAPIURL: ptr.To("https://api.prefect.cloud"),
-					AccountID:    ptr.To(accountID),
-					WorkspaceID:  ptr.To(workspaceID),
+					RemoteAPIURL: new("https://api.prefect.cloud"),
+					AccountID:    new(accountID),
+					WorkspaceID:  new(workspaceID),
 					APIKey: &prefectiov1.APIKeySpec{
 						ValueFrom: &corev1.EnvVarSource{
 							SecretKeyRef: &corev1.SecretKeySelector{
@@ -1055,7 +1054,7 @@ var _ = Describe("PrefectWorkPool Controller", func() {
 				Spec: prefectiov1.PrefectWorkPoolSpec{
 					Type:               "kubernetes",
 					Workers:            1,
-					ServiceAccountName: ptr.To("prefect-worker"),
+					ServiceAccountName: new("prefect-worker"),
 					Server: prefectiov1.PrefectServerReference{
 						Name: "test-server",
 					},
@@ -1122,7 +1121,7 @@ var _ = Describe("PrefectWorkPool Controller", func() {
 				Spec: prefectiov1.PrefectWorkPoolSpec{
 					Type:               "kubernetes",
 					Workers:            1,
-					ServiceAccountName: ptr.To(""),
+					ServiceAccountName: new(""),
 					Server: prefectiov1.PrefectServerReference{
 						Name: "test-server",
 					},

--- a/internal/portforward/portforward.go
+++ b/internal/portforward/portforward.go
@@ -33,7 +33,7 @@ func (p *KubectlPortForwarder) ForwardPorts(stopCh <-chan struct{}, readyCh chan
 
 	// Wait for the port-forwarding to be ready
 	ready := false
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/health", p.LocalPort))
 		if err == nil {
 			_ = resp.Body.Close()

--- a/internal/prefect/client.go
+++ b/internal/prefect/client.go
@@ -157,50 +157,50 @@ func NewClientFromK8s(ctx context.Context, serverRef *prefectiov1.PrefectServerR
 
 // DeploymentSpec represents the request payload for creating/updating deployments
 type DeploymentSpec struct {
-	Name                    string                   `json:"name"`
-	FlowID                  string                   `json:"flow_id"`
-	Description             *string                  `json:"description,omitempty"`
-	Version                 *string                  `json:"version,omitempty"`
-	Tags                    []string                 `json:"tags,omitempty"`
-	Parameters              map[string]interface{}   `json:"parameters,omitempty"`
-	JobVariables            map[string]interface{}   `json:"job_variables,omitempty"`
-	WorkQueueName           *string                  `json:"work_queue_name,omitempty"`
-	WorkPoolName            *string                  `json:"work_pool_name,omitempty"`
-	Paused                  *bool                    `json:"paused,omitempty"`
-	Schedules               []DeploymentSchedule     `json:"schedules,omitempty"`
-	ConcurrencyLimit        *int                     `json:"concurrency_limit,omitempty"`
-	GlobalConcurrencyLimits []string                 `json:"global_concurrency_limits,omitempty"`
-	Entrypoint              *string                  `json:"entrypoint,omitempty"`
-	Path                    *string                  `json:"path,omitempty"`
-	PullSteps               []map[string]interface{} `json:"pull_steps,omitempty"`
-	ParameterOpenAPISchema  map[string]interface{}   `json:"parameter_openapi_schema,omitempty"`
-	EnforceParameterSchema  *bool                    `json:"enforce_parameter_schema,omitempty"`
+	Name                    string               `json:"name"`
+	FlowID                  string               `json:"flow_id"`
+	Description             *string              `json:"description,omitempty"`
+	Version                 *string              `json:"version,omitempty"`
+	Tags                    []string             `json:"tags,omitempty"`
+	Parameters              map[string]any       `json:"parameters,omitempty"`
+	JobVariables            map[string]any       `json:"job_variables,omitempty"`
+	WorkQueueName           *string              `json:"work_queue_name,omitempty"`
+	WorkPoolName            *string              `json:"work_pool_name,omitempty"`
+	Paused                  *bool                `json:"paused,omitempty"`
+	Schedules               []DeploymentSchedule `json:"schedules,omitempty"`
+	ConcurrencyLimit        *int                 `json:"concurrency_limit,omitempty"`
+	GlobalConcurrencyLimits []string             `json:"global_concurrency_limits,omitempty"`
+	Entrypoint              *string              `json:"entrypoint,omitempty"`
+	Path                    *string              `json:"path,omitempty"`
+	PullSteps               []map[string]any     `json:"pull_steps,omitempty"`
+	ParameterOpenAPISchema  map[string]any       `json:"parameter_openapi_schema,omitempty"`
+	EnforceParameterSchema  *bool                `json:"enforce_parameter_schema,omitempty"`
 }
 
 // Deployment represents a Prefect deployment
 type Deployment struct {
-	ID                      string                   `json:"id"`
-	Created                 time.Time                `json:"created"`
-	Updated                 time.Time                `json:"updated"`
-	Name                    string                   `json:"name"`
-	Version                 *string                  `json:"version"`
-	Description             *string                  `json:"description"`
-	FlowID                  string                   `json:"flow_id"`
-	Paused                  bool                     `json:"paused"`
-	Tags                    []string                 `json:"tags"`
-	Parameters              map[string]interface{}   `json:"parameters"`
-	JobVariables            map[string]interface{}   `json:"job_variables"`
-	WorkQueueName           *string                  `json:"work_queue_name"`
-	WorkPoolName            *string                  `json:"work_pool_name"`
-	Status                  string                   `json:"status"`
-	Schedules               []DeploymentSchedule     `json:"schedules"`
-	ConcurrencyLimit        *int                     `json:"concurrency_limit"`
-	GlobalConcurrencyLimits []string                 `json:"global_concurrency_limits"`
-	Entrypoint              *string                  `json:"entrypoint"`
-	Path                    *string                  `json:"path"`
-	PullSteps               []map[string]interface{} `json:"pull_steps"`
-	ParameterOpenAPISchema  map[string]interface{}   `json:"parameter_openapi_schema"`
-	EnforceParameterSchema  bool                     `json:"enforce_parameter_schema"`
+	ID                      string               `json:"id"`
+	Created                 time.Time            `json:"created"`
+	Updated                 time.Time            `json:"updated"`
+	Name                    string               `json:"name"`
+	Version                 *string              `json:"version"`
+	Description             *string              `json:"description"`
+	FlowID                  string               `json:"flow_id"`
+	Paused                  bool                 `json:"paused"`
+	Tags                    []string             `json:"tags"`
+	Parameters              map[string]any       `json:"parameters"`
+	JobVariables            map[string]any       `json:"job_variables"`
+	WorkQueueName           *string              `json:"work_queue_name"`
+	WorkPoolName            *string              `json:"work_pool_name"`
+	Status                  string               `json:"status"`
+	Schedules               []DeploymentSchedule `json:"schedules"`
+	ConcurrencyLimit        *int                 `json:"concurrency_limit"`
+	GlobalConcurrencyLimits []string             `json:"global_concurrency_limits"`
+	Entrypoint              *string              `json:"entrypoint"`
+	Path                    *string              `json:"path"`
+	PullSteps               []map[string]any     `json:"pull_steps"`
+	ParameterOpenAPISchema  map[string]any       `json:"parameter_openapi_schema"`
+	EnforceParameterSchema  bool                 `json:"enforce_parameter_schema"`
 }
 
 // Schedule represents a Prefect deployment schedule.
@@ -252,7 +252,7 @@ type DeploymentSchedule struct {
 	Catchup *bool `json:"catchup,omitempty"`
 
 	// Parameters are schedule-specific parameters
-	Parameters map[string]interface{} `json:"parameters,omitempty"`
+	Parameters map[string]any `json:"parameters,omitempty"`
 }
 
 // FlowSpec represents the request payload for creating flows
@@ -273,27 +273,27 @@ type Flow struct {
 }
 
 type WorkPoolSpec struct {
-	Name             string                 `json:"name,omitempty"`
-	Description      *string                `json:"description,omitempty"`
-	Type             string                 `json:"type,omitempty"`
-	BaseJobTemplate  map[string]interface{} `json:"base_job_template,omitempty"`
-	IsPaused         *bool                  `json:"is_paused,omitempty"`
-	ConcurrencyLimit *int                   `json:"concurrency_limit,omitempty"`
+	Name             string         `json:"name,omitempty"`
+	Description      *string        `json:"description,omitempty"`
+	Type             string         `json:"type,omitempty"`
+	BaseJobTemplate  map[string]any `json:"base_job_template,omitempty"`
+	IsPaused         *bool          `json:"is_paused,omitempty"`
+	ConcurrencyLimit *int           `json:"concurrency_limit,omitempty"`
 	// StorageConfiguration map[string]interface{} `json:"storage_configuration,omitempty"`
 }
 
 type WorkPool struct {
-	ID               string                 `json:"id"`
-	Created          time.Time              `json:"created"`
-	Updated          time.Time              `json:"updated"`
-	Name             string                 `json:"name"`
-	Type             string                 `json:"type"`
-	Description      *string                `json:"description"`
-	BaseJobTemplate  map[string]interface{} `json:"base_job_template"`
-	IsPaused         bool                   `json:"is_paused"`
-	ConcurrencyLimit *int                   `json:"concurrency_limit"`
-	Status           string                 `json:"status"`
-	DefaultQueueID   *string                `json:"default_queue_id"`
+	ID               string         `json:"id"`
+	Created          time.Time      `json:"created"`
+	Updated          time.Time      `json:"updated"`
+	Name             string         `json:"name"`
+	Type             string         `json:"type"`
+	Description      *string        `json:"description"`
+	BaseJobTemplate  map[string]any `json:"base_job_template"`
+	IsPaused         bool           `json:"is_paused"`
+	ConcurrencyLimit *int           `json:"concurrency_limit"`
+	Status           string         `json:"status"`
+	DefaultQueueID   *string        `json:"default_queue_id"`
 	// StorageConfiguration map[string]interface{} `json:"storage_configuration,omitempty"`
 }
 
@@ -742,14 +742,14 @@ func (c *Client) isRunningInCluster() bool {
 }
 
 type WorkerMetadata struct {
-	Type                   string                 `json:"type"`
-	Description            string                 `json:"description"`
-	DisplayName            string                 `json:"display_name"`
-	DocumentationURL       string                 `json:"documentation_url"`
-	InstallCommand         string                 `json:"install_command"`
-	IsBeta                 bool                   `json:"is_beta"`
-	LogoURL                string                 `json:"logo_url"`
-	DefaultBaseJobTemplate map[string]interface{} `json:"default_base_job_configuration"`
+	Type                   string         `json:"type"`
+	Description            string         `json:"description"`
+	DisplayName            string         `json:"display_name"`
+	DocumentationURL       string         `json:"documentation_url"`
+	InstallCommand         string         `json:"install_command"`
+	IsBeta                 bool           `json:"is_beta"`
+	LogoURL                string         `json:"logo_url"`
+	DefaultBaseJobTemplate map[string]any `json:"default_base_job_configuration"`
 }
 
 // GetWorkerMetadata retrieves aggregate metadata for all worker types

--- a/internal/prefect/client.go
+++ b/internal/prefect/client.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"time"
 
@@ -794,9 +795,7 @@ func (c *Client) GetWorkerMetadata(ctx context.Context) (map[string]WorkerMetada
 	metadata := map[string]WorkerMetadata{}
 
 	for _, integration := range result {
-		for workerType, worker := range integration {
-			metadata[workerType] = worker
-		}
+		maps.Copy(metadata, integration)
 	}
 
 	return metadata, nil

--- a/internal/prefect/client_test.go
+++ b/internal/prefect/client_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/ptr"
 )
 
 func TestPrefectClient(t *testing.T) {
@@ -454,9 +453,9 @@ var _ = Describe("Prefect HTTP Client", func() {
 				FlowID:       "flow-123",
 				Paused:       false,
 				Tags:         []string{"test", "deployment"},
-				Parameters:   map[string]interface{}{"param1": "value1"},
-				Entrypoint:   ptr.To("flows.py:main_flow"),
-				WorkPoolName: ptr.To("kubernetes"),
+				Parameters:   map[string]any{"param1": "value1"},
+				Entrypoint:   new("flows.py:main_flow"),
+				WorkPoolName: new("kubernetes"),
 			}
 
 			mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -484,9 +483,9 @@ var _ = Describe("Prefect HTTP Client", func() {
 				Name:         "test-deployment",
 				FlowID:       "flow-123",
 				Tags:         []string{"test", "deployment"},
-				Parameters:   map[string]interface{}{"param1": "value1"},
-				Entrypoint:   ptr.To("flows.py:main_flow"),
-				WorkPoolName: ptr.To("kubernetes"),
+				Parameters:   map[string]any{"param1": "value1"},
+				Entrypoint:   new("flows.py:main_flow"),
+				WorkPoolName: new("kubernetes"),
 			}
 			deployment, err := client.CreateOrUpdateDeployment(ctx, deploymentSpec)
 
@@ -511,7 +510,7 @@ var _ = Describe("Prefect HTTP Client", func() {
 				Paused:       false,
 				Status:       "READY",
 				Tags:         []string{"test"},
-				WorkPoolName: ptr.To("kubernetes"),
+				WorkPoolName: new("kubernetes"),
 			}
 
 			mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -550,8 +549,8 @@ var _ = Describe("Prefect HTTP Client", func() {
 				FlowID:       "flow-123",
 				Paused:       true,
 				Tags:         []string{"updated", "test"},
-				Parameters:   map[string]interface{}{"param1": "updated_value"},
-				WorkPoolName: ptr.To("kubernetes"),
+				Parameters:   map[string]any{"param1": "updated_value"},
+				WorkPoolName: new("kubernetes"),
 			}
 
 			mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -578,9 +577,9 @@ var _ = Describe("Prefect HTTP Client", func() {
 			deploymentSpec := &DeploymentSpec{
 				Name:       "updated-deployment",
 				FlowID:     "flow-123",
-				Paused:     ptr.To(true),
+				Paused:     new(true),
 				Tags:       []string{"updated", "test"},
-				Parameters: map[string]interface{}{"param1": "updated_value"},
+				Parameters: map[string]any{"param1": "updated_value"},
 			}
 			deployment, err := client.UpdateDeployment(ctx, "deployment-12345", deploymentSpec)
 
@@ -849,7 +848,7 @@ var _ = Describe("Prefect HTTP Client", func() {
 
 					// This test verifies the fix works for remote servers (to avoid port-forwarding issues)
 					serverRefWithRemote := &prefectiov1.PrefectServerReference{
-						RemoteAPIURL: ptr.To("https://api.prefect.cloud"),
+						RemoteAPIURL: new("https://api.prefect.cloud"),
 					}
 
 					client, err := NewClientFromServerReference(serverRefWithRemote, "test-key", "fallback-namespace", logger)
@@ -868,7 +867,7 @@ var _ = Describe("Prefect HTTP Client", func() {
 			Context("when server reference has remote server", func() {
 				It("should use remote API URL", func() {
 					serverRef = &prefectiov1.PrefectServerReference{
-						RemoteAPIURL: ptr.To("https://api.prefect.cloud"),
+						RemoteAPIURL: new("https://api.prefect.cloud"),
 					}
 
 					client, err := NewClientFromServerReference(serverRef, "test-key", "test-namespace", logger)
@@ -946,7 +945,7 @@ var _ = Describe("Prefect HTTP Client", func() {
 				It("should correctly use fallback namespace after fix (VERIFICATION)", func() {
 					// Use remote server reference to test NewClientFromK8s without port-forwarding
 					serverRef := &prefectiov1.PrefectServerReference{
-						RemoteAPIURL: ptr.To("https://api.prefect.cloud"),
+						RemoteAPIURL: new("https://api.prefect.cloud"),
 					}
 
 					client, err := NewClientFromK8s(ctx, serverRef, nil, "deployment-namespace", logger)
@@ -969,7 +968,7 @@ var _ = Describe("Prefect HTTP Client", func() {
 			Context("with remote server reference", func() {
 				It("should use remote API URL regardless of namespace", func() {
 					serverRef = &prefectiov1.PrefectServerReference{
-						RemoteAPIURL: ptr.To("https://api.prefect.cloud"),
+						RemoteAPIURL: new("https://api.prefect.cloud"),
 					}
 
 					client, err := NewClientFromK8s(ctx, serverRef, nil, "deployment-namespace", logger)

--- a/internal/prefect/convert.go
+++ b/internal/prefect/convert.go
@@ -57,7 +57,7 @@ func ConvertToDeploymentSpec(k8sDeployment *prefectiov1.PrefectDeployment, flowI
 
 	// Parameters
 	if deployment.Parameters != nil {
-		var params map[string]interface{}
+		var params map[string]any
 		if err := json.Unmarshal(deployment.Parameters.Raw, &params); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal parameters: %w", err)
 		}
@@ -66,7 +66,7 @@ func ConvertToDeploymentSpec(k8sDeployment *prefectiov1.PrefectDeployment, flowI
 
 	// Job variables
 	if deployment.JobVariables != nil {
-		var jobVars map[string]interface{}
+		var jobVars map[string]any
 		if err := json.Unmarshal(deployment.JobVariables.Raw, &jobVars); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal job variables: %w", err)
 		}
@@ -75,7 +75,7 @@ func ConvertToDeploymentSpec(k8sDeployment *prefectiov1.PrefectDeployment, flowI
 
 	// Parameter OpenAPI schema
 	if deployment.ParameterOpenApiSchema != nil {
-		var schema map[string]interface{}
+		var schema map[string]any
 		if err := json.Unmarshal(deployment.ParameterOpenApiSchema.Raw, &schema); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal parameter schema: %w", err)
 		}
@@ -87,9 +87,9 @@ func ConvertToDeploymentSpec(k8sDeployment *prefectiov1.PrefectDeployment, flowI
 
 	// Pull steps
 	if deployment.PullSteps != nil {
-		pullSteps := make([]map[string]interface{}, len(deployment.PullSteps))
+		pullSteps := make([]map[string]any, len(deployment.PullSteps))
 		for i, step := range deployment.PullSteps {
-			var stepMap map[string]interface{}
+			var stepMap map[string]any
 			if err := json.Unmarshal(step.Raw, &stepMap); err != nil {
 				return nil, fmt.Errorf("failed to unmarshal pull step %d: %w", i, err)
 			}

--- a/internal/prefect/convert.go
+++ b/internal/prefect/convert.go
@@ -182,12 +182,12 @@ func UpdateDeploymentStatus(k8sDeployment *prefectiov1.PrefectDeployment, prefec
 func GetFlowIDFromDeployment(ctx context.Context, client PrefectClient, k8sDeployment *prefectiov1.PrefectDeployment) (string, error) {
 	entryPoint := k8sDeployment.Spec.Deployment.Entrypoint
 
-	idx := strings.Index(entryPoint, ":")
-	if idx == -1 {
+	_, after, ok := strings.Cut(entryPoint, ":")
+	if !ok {
 		return "", fmt.Errorf("invalid entrypoint format (missing ':'): %s", entryPoint)
 	}
 
-	flowName := entryPoint[idx+1:]
+	flowName := after
 
 	flowSpec := &FlowSpec{
 		Name:   flowName,

--- a/internal/prefect/convert_test.go
+++ b/internal/prefect/convert_test.go
@@ -25,7 +25,6 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("ConvertToDeploymentSpec", func() {
@@ -60,8 +59,8 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 			Expect(spec).NotTo(BeNil())
 			Expect(spec.Name).To(Equal("test-deployment"))
 			Expect(spec.FlowID).To(Equal(flowID))
-			Expect(spec.Entrypoint).To(Equal(ptr.To("flows.py:main_flow")))
-			Expect(spec.WorkPoolName).To(Equal(ptr.To("test-workpool")))
+			Expect(spec.Entrypoint).To(Equal(new("flows.py:main_flow")))
+			Expect(spec.WorkPoolName).To(Equal(new("test-workpool")))
 		})
 	})
 
@@ -77,13 +76,13 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 
 		It("Should handle valid version info", func() {
 			k8sDeployment.Spec.Deployment.VersionInfo = &prefectiov1.PrefectVersionInfo{
-				Version: ptr.To("v1.0.0"),
+				Version: new("v1.0.0"),
 			}
 
 			spec, err := ConvertToDeploymentSpec(k8sDeployment, flowID)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(spec.Version).To(Equal(ptr.To("v1.0.0")))
+			Expect(spec.Version).To(Equal(new("v1.0.0")))
 		})
 	})
 
@@ -98,12 +97,12 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 		})
 
 		It("Should handle valid work queue", func() {
-			k8sDeployment.Spec.WorkPool.WorkQueue = ptr.To("test-queue")
+			k8sDeployment.Spec.WorkPool.WorkQueue = new("test-queue")
 
 			spec, err := ConvertToDeploymentSpec(k8sDeployment, flowID)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(spec.WorkQueueName).To(Equal(ptr.To("test-queue")))
+			Expect(spec.WorkQueueName).To(Equal(new("test-queue")))
 		})
 	})
 
@@ -118,7 +117,7 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 		})
 
 		It("Should handle valid parameters", func() {
-			params := map[string]interface{}{
+			params := map[string]any{
 				"key1": "value1",
 				"key2": 42,
 			}
@@ -160,7 +159,7 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 		})
 
 		It("Should handle valid job variables", func() {
-			jobVars := map[string]interface{}{
+			jobVars := map[string]any{
 				"cpu":    "100m",
 				"memory": "128Mi",
 			}
@@ -199,10 +198,10 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 		})
 
 		It("Should handle valid parameter schema", func() {
-			schema := map[string]interface{}{
+			schema := map[string]any{
 				"type": "object",
-				"properties": map[string]interface{}{
-					"name": map[string]interface{}{
+				"properties": map[string]any{
+					"name": map[string]any{
 						"type": "string",
 					},
 				},
@@ -242,13 +241,13 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 		})
 
 		It("Should handle valid pull steps", func() {
-			pullStep1 := map[string]interface{}{
-				"prefect.deployments.steps.git_clone": map[string]interface{}{
+			pullStep1 := map[string]any{
+				"prefect.deployments.steps.git_clone": map[string]any{
 					"repository": "https://github.com/org/repo.git",
 				},
 			}
-			pullStep2 := map[string]interface{}{
-				"prefect.deployments.steps.pip_install_requirements": map[string]interface{}{
+			pullStep2 := map[string]any{
+				"prefect.deployments.steps.pip_install_requirements": map[string]any{
 					"requirements_file": "requirements.txt",
 				},
 			}
@@ -281,7 +280,7 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 		})
 
 		It("Should return error for invalid pull step JSON in second step", func() {
-			validStep := map[string]interface{}{"valid": "step"}
+			validStep := map[string]any{"valid": "step"}
 			validStepJSON, _ := json.Marshal(validStep)
 			k8sDeployment.Spec.Deployment.PullSteps = []runtime.RawExtension{
 				{Raw: validStepJSON},
@@ -311,9 +310,9 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 				k8sDeployment.Spec.Deployment.Schedules = []prefectiov1.PrefectSchedule{
 					{
 						Slug:     "daily-interval",
-						Interval: ptr.To(86400), // 1 day in seconds
-						Timezone: ptr.To("UTC"),
-						Active:   ptr.To(true),
+						Interval: new(86400), // 1 day in seconds
+						Timezone: new("UTC"),
+						Active:   new(true),
 					},
 				}
 
@@ -321,9 +320,9 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(spec.Schedules).To(HaveLen(1))
-				Expect(spec.Schedules[0].Schedule.Interval).To(Equal(ptr.To(float64(86400))))
-				Expect(spec.Schedules[0].Schedule.Timezone).To(Equal(ptr.To("UTC")))
-				Expect(spec.Schedules[0].Active).To(Equal(ptr.To(true)))
+				Expect(spec.Schedules[0].Schedule.Interval).To(Equal(new(float64(86400))))
+				Expect(spec.Schedules[0].Schedule.Timezone).To(Equal(new("UTC")))
+				Expect(spec.Schedules[0].Active).To(Equal(new(true)))
 				Expect(spec.Schedules[0].Schedule.AnchorDate).To(BeNil())
 				// Ensure other schedule types are nil
 				Expect(spec.Schedules[0].Schedule.Cron).To(BeNil())
@@ -334,10 +333,10 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 				k8sDeployment.Spec.Deployment.Schedules = []prefectiov1.PrefectSchedule{
 					{
 						Slug:             "daily-interval",
-						Interval:         ptr.To(86400),
-						AnchorDate:       ptr.To("2024-01-01T00:00:00Z"),
-						Timezone:         ptr.To("UTC"),
-						MaxScheduledRuns: ptr.To(10),
+						Interval:         new(86400),
+						AnchorDate:       new("2024-01-01T00:00:00Z"),
+						Timezone:         new("UTC"),
+						MaxScheduledRuns: new(10),
 					},
 				}
 
@@ -345,18 +344,18 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(spec.Schedules).To(HaveLen(1))
-				Expect(spec.Schedules[0].Schedule.Interval).To(Equal(ptr.To(float64(86400))))
+				Expect(spec.Schedules[0].Schedule.Interval).To(Equal(new(float64(86400))))
 				Expect(spec.Schedules[0].Schedule.AnchorDate).NotTo(BeNil())
 				Expect(spec.Schedules[0].Schedule.AnchorDate.Year()).To(Equal(2024))
-				Expect(spec.Schedules[0].MaxScheduledRuns).To(Equal(ptr.To(10)))
+				Expect(spec.Schedules[0].MaxScheduledRuns).To(Equal(new(10)))
 			})
 
 			It("Should return error for invalid anchor date format", func() {
 				k8sDeployment.Spec.Deployment.Schedules = []prefectiov1.PrefectSchedule{
 					{
 						Slug:       "daily-interval",
-						Interval:   ptr.To(86400),
-						AnchorDate: ptr.To("invalid-date-format"),
+						Interval:   new(86400),
+						AnchorDate: new("invalid-date-format"),
 					},
 				}
 
@@ -373,10 +372,10 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 				k8sDeployment.Spec.Deployment.Schedules = []prefectiov1.PrefectSchedule{
 					{
 						Slug:     "daily-9am",
-						Cron:     ptr.To("0 9 * * *"),
-						DayOr:    ptr.To(true),
-						Timezone: ptr.To("America/New_York"),
-						Active:   ptr.To(true),
+						Cron:     new("0 9 * * *"),
+						DayOr:    new(true),
+						Timezone: new("America/New_York"),
+						Active:   new(true),
 					},
 				}
 
@@ -384,10 +383,10 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(spec.Schedules).To(HaveLen(1))
-				Expect(spec.Schedules[0].Schedule.Cron).To(Equal(ptr.To("0 9 * * *")))
-				Expect(spec.Schedules[0].Schedule.DayOr).To(Equal(ptr.To(true)))
-				Expect(spec.Schedules[0].Schedule.Timezone).To(Equal(ptr.To("America/New_York")))
-				Expect(spec.Schedules[0].Active).To(Equal(ptr.To(true)))
+				Expect(spec.Schedules[0].Schedule.Cron).To(Equal(new("0 9 * * *")))
+				Expect(spec.Schedules[0].Schedule.DayOr).To(Equal(new(true)))
+				Expect(spec.Schedules[0].Schedule.Timezone).To(Equal(new("America/New_York")))
+				Expect(spec.Schedules[0].Active).To(Equal(new(true)))
 				// Ensure other schedule types are nil
 				Expect(spec.Schedules[0].Schedule.Interval).To(BeNil())
 				Expect(spec.Schedules[0].Schedule.AnchorDate).To(BeNil())
@@ -398,10 +397,10 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 				k8sDeployment.Spec.Deployment.Schedules = []prefectiov1.PrefectSchedule{
 					{
 						Slug:             "every-5-minutes",
-						Cron:             ptr.To("*/5 * * * *"),
-						Timezone:         ptr.To("UTC"),
-						Active:           ptr.To(true),
-						MaxScheduledRuns: ptr.To(100),
+						Cron:             new("*/5 * * * *"),
+						Timezone:         new("UTC"),
+						Active:           new(true),
+						MaxScheduledRuns: new(100),
 					},
 				}
 
@@ -409,9 +408,9 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(spec.Schedules).To(HaveLen(1))
-				Expect(spec.Schedules[0].Schedule.Cron).To(Equal(ptr.To("*/5 * * * *")))
+				Expect(spec.Schedules[0].Schedule.Cron).To(Equal(new("*/5 * * * *")))
 				Expect(spec.Schedules[0].Schedule.DayOr).To(BeNil()) // Should be nil when not specified
-				Expect(spec.Schedules[0].MaxScheduledRuns).To(Equal(ptr.To(100)))
+				Expect(spec.Schedules[0].MaxScheduledRuns).To(Equal(new(100)))
 			})
 		})
 
@@ -420,9 +419,9 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 				k8sDeployment.Spec.Deployment.Schedules = []prefectiov1.PrefectSchedule{
 					{
 						Slug:     "weekly-monday",
-						RRule:    ptr.To("RRULE:FREQ=WEEKLY;BYDAY=MO"),
-						Timezone: ptr.To("UTC"),
-						Active:   ptr.To(true),
+						RRule:    new("RRULE:FREQ=WEEKLY;BYDAY=MO"),
+						Timezone: new("UTC"),
+						Active:   new(true),
 					},
 				}
 
@@ -430,9 +429,9 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(spec.Schedules).To(HaveLen(1))
-				Expect(spec.Schedules[0].Schedule.RRule).To(Equal(ptr.To("RRULE:FREQ=WEEKLY;BYDAY=MO")))
-				Expect(spec.Schedules[0].Schedule.Timezone).To(Equal(ptr.To("UTC")))
-				Expect(spec.Schedules[0].Active).To(Equal(ptr.To(true)))
+				Expect(spec.Schedules[0].Schedule.RRule).To(Equal(new("RRULE:FREQ=WEEKLY;BYDAY=MO")))
+				Expect(spec.Schedules[0].Schedule.Timezone).To(Equal(new("UTC")))
+				Expect(spec.Schedules[0].Active).To(Equal(new(true)))
 				// Ensure other schedule types are nil
 				Expect(spec.Schedules[0].Schedule.Interval).To(BeNil())
 				Expect(spec.Schedules[0].Schedule.AnchorDate).To(BeNil())
@@ -444,10 +443,10 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 				k8sDeployment.Spec.Deployment.Schedules = []prefectiov1.PrefectSchedule{
 					{
 						Slug:             "monthly-first-friday",
-						RRule:            ptr.To("RRULE:FREQ=MONTHLY;BYDAY=1FR"),
-						Timezone:         ptr.To("America/Los_Angeles"),
-						Active:           ptr.To(true),
-						MaxScheduledRuns: ptr.To(12),
+						RRule:            new("RRULE:FREQ=MONTHLY;BYDAY=1FR"),
+						Timezone:         new("America/Los_Angeles"),
+						Active:           new(true),
+						MaxScheduledRuns: new(12),
 					},
 				}
 
@@ -455,9 +454,9 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(spec.Schedules).To(HaveLen(1))
-				Expect(spec.Schedules[0].Schedule.RRule).To(Equal(ptr.To("RRULE:FREQ=MONTHLY;BYDAY=1FR")))
-				Expect(spec.Schedules[0].Schedule.Timezone).To(Equal(ptr.To("America/Los_Angeles")))
-				Expect(spec.Schedules[0].MaxScheduledRuns).To(Equal(ptr.To(12)))
+				Expect(spec.Schedules[0].Schedule.RRule).To(Equal(new("RRULE:FREQ=MONTHLY;BYDAY=1FR")))
+				Expect(spec.Schedules[0].Schedule.Timezone).To(Equal(new("America/Los_Angeles")))
+				Expect(spec.Schedules[0].MaxScheduledRuns).To(Equal(new(12)))
 			})
 		})
 
@@ -466,23 +465,23 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 				k8sDeployment.Spec.Deployment.Schedules = []prefectiov1.PrefectSchedule{
 					{
 						Slug:       "hourly-interval",
-						Interval:   ptr.To(3600),
-						AnchorDate: ptr.To("2024-01-01T00:00:00Z"),
-						Timezone:   ptr.To("UTC"),
-						Active:     ptr.To(true),
+						Interval:   new(3600),
+						AnchorDate: new("2024-01-01T00:00:00Z"),
+						Timezone:   new("UTC"),
+						Active:     new(true),
 					},
 					{
 						Slug:     "daily-cron",
-						Cron:     ptr.To("0 9 * * *"),
-						DayOr:    ptr.To(false),
-						Timezone: ptr.To("America/New_York"),
-						Active:   ptr.To(true),
+						Cron:     new("0 9 * * *"),
+						DayOr:    new(false),
+						Timezone: new("America/New_York"),
+						Active:   new(true),
 					},
 					{
 						Slug:     "weekly-rrule",
-						RRule:    ptr.To("RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"),
-						Timezone: ptr.To("Europe/London"),
-						Active:   ptr.To(true),
+						RRule:    new("RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"),
+						Timezone: new("Europe/London"),
+						Active:   new(true),
 					},
 				}
 
@@ -492,19 +491,19 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 				Expect(spec.Schedules).To(HaveLen(3))
 
 				// Interval schedule
-				Expect(spec.Schedules[0].Schedule.Interval).To(Equal(ptr.To(float64(3600))))
+				Expect(spec.Schedules[0].Schedule.Interval).To(Equal(new(float64(3600))))
 				Expect(spec.Schedules[0].Schedule.AnchorDate).NotTo(BeNil())
 				Expect(spec.Schedules[0].Schedule.Cron).To(BeNil())
 				Expect(spec.Schedules[0].Schedule.RRule).To(BeNil())
 
 				// Cron schedule
-				Expect(spec.Schedules[1].Schedule.Cron).To(Equal(ptr.To("0 9 * * *")))
-				Expect(spec.Schedules[1].Schedule.DayOr).To(Equal(ptr.To(false)))
+				Expect(spec.Schedules[1].Schedule.Cron).To(Equal(new("0 9 * * *")))
+				Expect(spec.Schedules[1].Schedule.DayOr).To(Equal(new(false)))
 				Expect(spec.Schedules[1].Schedule.Interval).To(BeNil())
 				Expect(spec.Schedules[1].Schedule.RRule).To(BeNil())
 
 				// RRule schedule
-				Expect(spec.Schedules[2].Schedule.RRule).To(Equal(ptr.To("RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR")))
+				Expect(spec.Schedules[2].Schedule.RRule).To(Equal(new("RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR")))
 				Expect(spec.Schedules[2].Schedule.Interval).To(BeNil())
 				Expect(spec.Schedules[2].Schedule.Cron).To(BeNil())
 			})
@@ -515,8 +514,8 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 				k8sDeployment.Spec.Deployment.Schedules = []prefectiov1.PrefectSchedule{
 					{
 						Slug:     "empty-schedule",
-						Timezone: ptr.To("UTC"),
-						Active:   ptr.To(true),
+						Timezone: new("UTC"),
+						Active:   new(true),
 						// No interval, cron, or rrule specified
 					},
 				}
@@ -532,10 +531,10 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 				k8sDeployment.Spec.Deployment.Schedules = []prefectiov1.PrefectSchedule{
 					{
 						Slug:     "invalid-schedule",
-						Interval: ptr.To(3600),        // interval specified
-						Cron:     ptr.To("0 9 * * *"), // cron also specified - invalid!
-						Timezone: ptr.To("UTC"),
-						Active:   ptr.To(true),
+						Interval: new(3600),        // interval specified
+						Cron:     new("0 9 * * *"), // cron also specified - invalid!
+						Timezone: new("UTC"),
+						Active:   new(true),
 					},
 				}
 
@@ -550,11 +549,11 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 				k8sDeployment.Spec.Deployment.Schedules = []prefectiov1.PrefectSchedule{
 					{
 						Slug:     "invalid-schedule",
-						Interval: ptr.To(3600),                         // interval specified
-						Cron:     ptr.To("0 9 * * *"),                  // cron specified
-						RRule:    ptr.To("RRULE:FREQ=WEEKLY;BYDAY=MO"), // rrule specified - all three invalid!
-						Timezone: ptr.To("UTC"),
-						Active:   ptr.To(true),
+						Interval: new(3600),                         // interval specified
+						Cron:     new("0 9 * * *"),                  // cron specified
+						RRule:    new("RRULE:FREQ=WEEKLY;BYDAY=MO"), // rrule specified - all three invalid!
+						Timezone: new("UTC"),
+						Active:   new(true),
 					},
 				}
 
@@ -592,10 +591,10 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 	Context("Complete deployment with all fields", func() {
 		It("Should handle deployment with all optional fields populated", func() {
 			// Set up comprehensive deployment with all fields
-			params := map[string]interface{}{"param1": "value1"}
-			jobVars := map[string]interface{}{"cpu": "100m"}
-			schema := map[string]interface{}{"type": "object"}
-			pullStep := map[string]interface{}{"step": "git_clone"}
+			params := map[string]any{"param1": "value1"}
+			jobVars := map[string]any{"cpu": "100m"}
+			schema := map[string]any{"type": "object"}
+			pullStep := map[string]any{"step": "git_clone"}
 
 			paramsJSON, _ := json.Marshal(params)
 			jobVarsJSON, _ := json.Marshal(jobVars)
@@ -603,35 +602,35 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 			pullStepJSON, _ := json.Marshal(pullStep)
 
 			k8sDeployment.Spec.Deployment = prefectiov1.PrefectDeploymentConfiguration{
-				Description: ptr.To("Test deployment"),
+				Description: new("Test deployment"),
 				Tags:        []string{"test", "example"},
 				VersionInfo: &prefectiov1.PrefectVersionInfo{
-					Version: ptr.To("v1.0.0"),
+					Version: new("v1.0.0"),
 				},
 				Entrypoint:             "flows.py:main_flow",
-				Path:                   ptr.To("/opt/flows"),
+				Path:                   new("/opt/flows"),
 				Parameters:             &runtime.RawExtension{Raw: paramsJSON},
 				JobVariables:           &runtime.RawExtension{Raw: jobVarsJSON},
 				ParameterOpenApiSchema: &runtime.RawExtension{Raw: schemaJSON},
-				EnforceParameterSchema: ptr.To(true),
+				EnforceParameterSchema: new(true),
 				PullSteps:              []runtime.RawExtension{{Raw: pullStepJSON}},
-				Paused:                 ptr.To(false),
-				ConcurrencyLimit:       ptr.To(5),
+				Paused:                 new(false),
+				ConcurrencyLimit:       new(5),
 				GlobalConcurrencyLimit: &prefectiov1.PrefectGlobalConcurrencyLimit{
 					Name: "global-limit",
 				},
 				Schedules: []prefectiov1.PrefectSchedule{
 					{
 						Slug:             "test-schedule",
-						Interval:         ptr.To(3600),
-						AnchorDate:       ptr.To("2024-01-01T00:00:00Z"),
-						Timezone:         ptr.To("UTC"),
-						Active:           ptr.To(true),
-						MaxScheduledRuns: ptr.To(10),
+						Interval:         new(3600),
+						AnchorDate:       new("2024-01-01T00:00:00Z"),
+						Timezone:         new("UTC"),
+						Active:           new(true),
+						MaxScheduledRuns: new(10),
 					},
 				},
 			}
-			k8sDeployment.Spec.WorkPool.WorkQueue = ptr.To("test-queue")
+			k8sDeployment.Spec.WorkPool.WorkQueue = new("test-queue")
 
 			spec, err := ConvertToDeploymentSpec(k8sDeployment, flowID)
 
@@ -639,22 +638,22 @@ var _ = Describe("ConvertToDeploymentSpec", func() {
 			Expect(spec).NotTo(BeNil())
 
 			// Verify all fields are properly converted
-			Expect(spec.Description).To(Equal(ptr.To("Test deployment")))
+			Expect(spec.Description).To(Equal(new("Test deployment")))
 			Expect(spec.Tags).To(Equal([]string{"test", "example"}))
-			Expect(spec.Version).To(Equal(ptr.To("v1.0.0")))
-			Expect(spec.Path).To(Equal(ptr.To("/opt/flows")))
+			Expect(spec.Version).To(Equal(new("v1.0.0")))
+			Expect(spec.Path).To(Equal(new("/opt/flows")))
 			Expect(spec.Parameters).To(Equal(params))
 			Expect(spec.JobVariables).To(Equal(jobVars))
 			Expect(spec.ParameterOpenAPISchema).To(Equal(schema))
-			Expect(spec.EnforceParameterSchema).To(Equal(ptr.To(true)))
+			Expect(spec.EnforceParameterSchema).To(Equal(new(true)))
 			Expect(spec.PullSteps).To(HaveLen(1))
 			Expect(spec.PullSteps[0]).To(Equal(pullStep))
-			Expect(spec.Paused).To(Equal(ptr.To(false)))
-			Expect(spec.ConcurrencyLimit).To(Equal(ptr.To(5)))
+			Expect(spec.Paused).To(Equal(new(false)))
+			Expect(spec.ConcurrencyLimit).To(Equal(new(5)))
 			Expect(spec.GlobalConcurrencyLimits).To(Equal([]string{"global-limit"}))
-			Expect(spec.WorkQueueName).To(Equal(ptr.To("test-queue")))
+			Expect(spec.WorkQueueName).To(Equal(new("test-queue")))
 			Expect(spec.Schedules).To(HaveLen(1))
-			Expect(spec.Schedules[0].Schedule.Interval).To(Equal(ptr.To(float64(3600))))
+			Expect(spec.Schedules[0].Schedule.Interval).To(Equal(new(float64(3600))))
 		})
 	})
 })
@@ -683,8 +682,8 @@ var _ = Describe("UpdateDeploymentStatus", func() {
 	It("Should update status correctly", func() {
 		UpdateDeploymentStatus(k8sDeployment, prefectDeployment)
 
-		Expect(k8sDeployment.Status.Id).To(Equal(ptr.To("deployment-123")))
-		Expect(k8sDeployment.Status.FlowId).To(Equal(ptr.To("flow-456")))
+		Expect(k8sDeployment.Status.Id).To(Equal(new("deployment-123")))
+		Expect(k8sDeployment.Status.FlowId).To(Equal(new("flow-456")))
 		Expect(k8sDeployment.Status.Ready).To(BeTrue())
 	})
 

--- a/internal/prefect/mock.go
+++ b/internal/prefect/mock.go
@@ -129,10 +129,10 @@ func (m *MockClient) CreateOrUpdateDeployment(ctx context.Context, deployment *D
 		newDeployment.Tags = []string{}
 	}
 	if newDeployment.Parameters == nil {
-		newDeployment.Parameters = make(map[string]interface{})
+		newDeployment.Parameters = make(map[string]any)
 	}
 	if newDeployment.JobVariables == nil {
-		newDeployment.JobVariables = make(map[string]interface{})
+		newDeployment.JobVariables = make(map[string]any)
 	}
 	if newDeployment.Schedules == nil {
 		newDeployment.Schedules = []DeploymentSchedule{}
@@ -141,10 +141,10 @@ func (m *MockClient) CreateOrUpdateDeployment(ctx context.Context, deployment *D
 		newDeployment.GlobalConcurrencyLimits = []string{}
 	}
 	if newDeployment.PullSteps == nil {
-		newDeployment.PullSteps = []map[string]interface{}{}
+		newDeployment.PullSteps = []map[string]any{}
 	}
 	if newDeployment.ParameterOpenAPISchema == nil {
-		newDeployment.ParameterOpenAPISchema = make(map[string]interface{})
+		newDeployment.ParameterOpenAPISchema = make(map[string]any)
 	}
 
 	m.deployments[newDeployment.ID] = newDeployment
@@ -297,12 +297,12 @@ func (m *MockClient) copyDeployment(d *Deployment) *Deployment {
 	}
 
 	if d.Parameters != nil {
-		copy.Parameters = make(map[string]interface{})
+		copy.Parameters = make(map[string]any)
 		maps.Copy(copy.Parameters, d.Parameters)
 	}
 
 	if d.JobVariables != nil {
-		copy.JobVariables = make(map[string]interface{})
+		copy.JobVariables = make(map[string]any)
 		maps.Copy(copy.JobVariables, d.JobVariables)
 	}
 
@@ -321,15 +321,15 @@ func (m *MockClient) copyDeployment(d *Deployment) *Deployment {
 	}
 
 	if d.PullSteps != nil {
-		copy.PullSteps = make([]map[string]interface{}, len(d.PullSteps))
+		copy.PullSteps = make([]map[string]any, len(d.PullSteps))
 		for i, step := range d.PullSteps {
-			copy.PullSteps[i] = make(map[string]interface{})
+			copy.PullSteps[i] = make(map[string]any)
 			maps.Copy(copy.PullSteps[i], step)
 		}
 	}
 
 	if d.ParameterOpenAPISchema != nil {
-		copy.ParameterOpenAPISchema = make(map[string]interface{})
+		copy.ParameterOpenAPISchema = make(map[string]any)
 		maps.Copy(copy.ParameterOpenAPISchema, d.ParameterOpenAPISchema)
 	}
 
@@ -457,7 +457,7 @@ func (m *MockClient) CreateWorkPool(ctx context.Context, workPool *WorkPoolSpec)
 	}
 
 	if newWorkPool.BaseJobTemplate == nil {
-		newWorkPool.BaseJobTemplate = make(map[string]interface{})
+		newWorkPool.BaseJobTemplate = make(map[string]any)
 	}
 
 	m.workPools[newWorkPool.Name] = newWorkPool
@@ -514,17 +514,17 @@ func (m *MockClient) copyWorkPool(w *WorkPool) *WorkPool {
 	copy := *w
 
 	if w.BaseJobTemplate != nil {
-		copy.BaseJobTemplate = make(map[string]interface{})
+		copy.BaseJobTemplate = make(map[string]any)
 		maps.Copy(copy.BaseJobTemplate, w.BaseJobTemplate)
 	}
 
 	return &copy
 }
 
-var MockDefaultBaseJobTemplate = map[string]interface{}{
+var MockDefaultBaseJobTemplate = map[string]any{
 	"foo":  "bar",
 	"quux": true,
-	"boz":  []interface{}{"baz", "bot", "biz"},
+	"boz":  []any{"baz", "bot", "biz"},
 }
 
 // TODO - implement when implementing unit tests

--- a/internal/prefect/mock.go
+++ b/internal/prefect/mock.go
@@ -19,6 +19,7 @@ package prefect
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -297,16 +298,12 @@ func (m *MockClient) copyDeployment(d *Deployment) *Deployment {
 
 	if d.Parameters != nil {
 		copy.Parameters = make(map[string]interface{})
-		for k, v := range d.Parameters {
-			copy.Parameters[k] = v
-		}
+		maps.Copy(copy.Parameters, d.Parameters)
 	}
 
 	if d.JobVariables != nil {
 		copy.JobVariables = make(map[string]interface{})
-		for k, v := range d.JobVariables {
-			copy.JobVariables[k] = v
-		}
+		maps.Copy(copy.JobVariables, d.JobVariables)
 	}
 
 	if d.Schedules != nil {
@@ -327,17 +324,13 @@ func (m *MockClient) copyDeployment(d *Deployment) *Deployment {
 		copy.PullSteps = make([]map[string]interface{}, len(d.PullSteps))
 		for i, step := range d.PullSteps {
 			copy.PullSteps[i] = make(map[string]interface{})
-			for k, v := range step {
-				copy.PullSteps[i][k] = v
-			}
+			maps.Copy(copy.PullSteps[i], step)
 		}
 	}
 
 	if d.ParameterOpenAPISchema != nil {
 		copy.ParameterOpenAPISchema = make(map[string]interface{})
-		for k, v := range d.ParameterOpenAPISchema {
-			copy.ParameterOpenAPISchema[k] = v
-		}
+		maps.Copy(copy.ParameterOpenAPISchema, d.ParameterOpenAPISchema)
 	}
 
 	return &copy
@@ -428,9 +421,7 @@ func (m *MockClient) copyFlow(f *Flow) *Flow {
 	}
 	if f.Labels != nil {
 		copy.Labels = make(map[string]string)
-		for k, v := range f.Labels {
-			copy.Labels[k] = v
-		}
+		maps.Copy(copy.Labels, f.Labels)
 	}
 
 	return &copy
@@ -524,9 +515,7 @@ func (m *MockClient) copyWorkPool(w *WorkPool) *WorkPool {
 
 	if w.BaseJobTemplate != nil {
 		copy.BaseJobTemplate = make(map[string]interface{})
-		for k, v := range w.BaseJobTemplate {
-			copy.BaseJobTemplate[k] = v
-		}
+		maps.Copy(copy.BaseJobTemplate, w.BaseJobTemplate)
 	}
 
 	return &copy

--- a/internal/utils/backoff_test.go
+++ b/internal/utils/backoff_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Backoff utilities", func() {
 		})
 
 		It("should detect when to stop retrying", func() {
-			for i := 0; i < MaxRetryAttempts-1; i++ {
+			for range MaxRetryAttempts - 1 {
 				IncrementRetryCount(workPool)
 				Expect(ShouldStopRetrying(workPool)).To(BeFalse())
 			}

--- a/internal/utils/hash.go
+++ b/internal/utils/hash.go
@@ -8,7 +8,7 @@ import (
 
 // Hash returns a hashed string based on an input object,
 // which is JSON serialized, and the length of the output.
-func Hash(obj interface{}, length int) (string, error) {
+func Hash(obj any, length int) (string, error) {
 	data, err := json.Marshal(obj) // Serialize the object to JSON
 	if err != nil {
 		return "", err

--- a/internal/utils/hash_test.go
+++ b/internal/utils/hash_test.go
@@ -6,7 +6,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 )
 
 func MigrationJobStub() *batchv1.Job {
@@ -16,7 +15,7 @@ func MigrationJobStub() *batchv1.Job {
 			Namespace: "default",
 		},
 		Spec: batchv1.JobSpec{
-			TTLSecondsAfterFinished: ptr.To(int32(60 * 60)), // 1 hour
+			TTLSecondsAfterFinished: new(int32(60 * 60)), // 1 hour
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{"app": "prefect-server"},

--- a/internal/utils/server_health_test.go
+++ b/internal/utils/server_health_test.go
@@ -21,7 +21,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/utils/ptr"
 
 	prefectiov1 "github.com/PrefectHQ/prefect-operator/api/v1"
 )
@@ -40,16 +39,16 @@ var _ = Describe("Server health utilities", func() {
 			serverRef := &prefectiov1.PrefectServerReference{
 				Name:         "prefect-ephemeral",
 				Namespace:    "default",
-				RemoteAPIURL: ptr.To("https://api.prefect.cloud/api/accounts/123/workspaces/456"),
+				RemoteAPIURL: new("https://api.prefect.cloud/api/accounts/123/workspaces/456"),
 			}
 			Expect(IsInClusterServer(serverRef)).To(BeFalse())
 		})
 
 		It("should identify Prefect Cloud servers", func() {
 			serverRef := &prefectiov1.PrefectServerReference{
-				RemoteAPIURL: ptr.To("https://api.prefect.cloud/api/accounts/123/workspaces/456"),
-				AccountID:    ptr.To("123"),
-				WorkspaceID:  ptr.To("456"),
+				RemoteAPIURL: new("https://api.prefect.cloud/api/accounts/123/workspaces/456"),
+				AccountID:    new("123"),
+				WorkspaceID:  new("456"),
 			}
 			Expect(IsInClusterServer(serverRef)).To(BeFalse())
 		})
@@ -69,7 +68,7 @@ var _ = Describe("Server health utilities", func() {
 
 		It("should handle external server references", func() {
 			serverRef := &prefectiov1.PrefectServerReference{
-				RemoteAPIURL: ptr.To("https://httpbin.org"),
+				RemoteAPIURL: new("https://httpbin.org"),
 			}
 
 			// This will fail because httpbin.org doesn't have /api/health endpoint

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -119,8 +119,8 @@ func LoadImageToKindClusterWithName(name string) error {
 // according to line breakers, and ignores the empty elements in it.
 func GetNonEmptyLines(output string) []string {
 	var res []string
-	elements := strings.Split(output, "\n")
-	for _, element := range elements {
+	elements := strings.SplitSeq(output, "\n")
+	for element := range elements {
 		if element != "" {
 			res = append(res, element)
 		}


### PR DESCRIPTION
## Summary

Bumps Go to 1.26 and applies the automated fixes from `go fix ./...` to modernize the codebase:

- Use `new()` builtin instead of `k8s.io/utils/ptr.To()` for generic pointer construction (drops `k8s.io/utils` as a direct dependency)
- Replace `interface{}` with the `any` type alias
- Use `maps.Copy` from the standard library instead of manual for-range map copying
- Use `strings.Contains`, `strings.Cut`, and `strings.SplitSeq` instead of older string functions
- Use `for range N` integer range syntax

All changes were produced by `go fix`, just split into separate commits by category.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Related to https://linear.app/prefect/issue/PLA-2340/apply-go-fix-changes-from-go-126