### PR TITLE
ci: build multiarch (amd64+arm64) operator images

### DIFF
--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -34,6 +34,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -69,6 +72,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ inputs.push }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}


### PR DESCRIPTION
## What

The operator image is currently published for **linux/amd64 only**, so it can't run on arm64 (e.g. Graviton) nodes — pods land in `ImagePullBackOff` with `no match for platform in manifest`.

This makes the build-and-push workflow produce a **multi-arch** image:
- add `docker/setup-qemu-action` (emulates the non-native arch on the amd64 runner — the standard companion to `setup-buildx-action` for multi-platform builds)
- set `platforms: linux/amd64,linux/arm64` on `docker/build-push-action`

No other changes; still uses the existing buildx (`setup-buildx-action` + `build-push-action`) path, tags, and registry.

## Why

Operators are increasingly run on mixed or arm64-only clusters; a single-arch image blocks that. buildx emits an OCI image index covering both arches under the same tag, so existing consumers are unaffected.