### PR TITLE
docs: link PrefectDeployment CRD in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ The [PrefectServer CRD](./PrefectServer.md)
 
 The [PrefectWorkPool CRD](./PrefectWorkPool.md)
 
+### PrefectDeployment
+
+The [PrefectDeployment CRD](./PrefectDeployment.md)
+
 ## Getting Started
 
 ### Prerequisites


### PR DESCRIPTION
The README's **Custom Resource Definitions** section lists PrefectServer and PrefectWorkPool, but not **PrefectDeployment** — even though `PrefectDeployment.md` already ships in the repo (and `make docs` generates it). This adds the missing entry.

```md
### PrefectDeployment

The [PrefectDeployment CRD](./PrefectDeployment.md)
```

Docs-only.