### PR TITLE
fix: harden PrefectAutomation controller (#294 follow-ups)

### DIFF
--- a/api/v1/prefectautomation_types.go
+++ b/api/v1/prefectautomation_types.go
@@ -184,6 +184,13 @@ type PrefectSequenceTrigger struct {
 	Triggers []PrefectChildTrigger `json:"triggers"`
 }
 
+// Deployment-target action types (their target is a deployment).
+const (
+	ActionRunDeployment    = "run-deployment"
+	ActionPauseDeployment  = "pause-deployment"
+	ActionResumeDeployment = "resume-deployment"
+)
+
 // PrefectAutomationAction matches Prefect's action union. `type` selects the
 // action; the remaining fields apply to the relevant action types.
 type PrefectAutomationAction struct {
@@ -325,6 +332,62 @@ func (a *PrefectAutomation) Validate() error {
 	}
 	if set != 1 {
 		return fmt.Errorf("exactly one of trigger.event, trigger.metric, trigger.compound, or trigger.sequence must be set (got %d)", set)
+	}
+
+	for _, list := range []struct {
+		field   string
+		actions []PrefectAutomationAction
+	}{
+		{"actions", a.Spec.Actions},
+		{"actionsOnTrigger", a.Spec.ActionsOnTrigger},
+		{"actionsOnResolve", a.Spec.ActionsOnResolve},
+	} {
+		for i := range list.actions {
+			if err := validateAction(list.field, i, list.actions[i]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// deploymentTargetActions are the action types whose target is a deployment.
+var deploymentTargetActions = map[string]struct{}{
+	ActionRunDeployment:    {},
+	ActionPauseDeployment:  {},
+	ActionResumeDeployment: {},
+}
+
+// validateAction enforces the deploymentId/deploymentName rules that mirror the
+// Prefect API: the two fields are two ways to supply the same deployment_id (so
+// never both), and for deployment-target actions the presence of a target is
+// governed by `source` ("selected" requires exactly one, "inferred" requires
+// neither). Source defaults to "selected" per the API.
+func validateAction(field string, i int, action PrefectAutomationAction) error {
+	hasID := action.DeploymentID != nil && *action.DeploymentID != ""
+	hasName := action.DeploymentName != nil && *action.DeploymentName != ""
+
+	if hasID && hasName {
+		return fmt.Errorf("%s[%d] (%s): deploymentId and deploymentName are mutually exclusive", field, i, action.Type)
+	}
+
+	if _, isDeploymentAction := deploymentTargetActions[action.Type]; !isDeploymentAction {
+		return nil
+	}
+
+	source := "selected"
+	if action.Source != nil && *action.Source != "" {
+		source = *action.Source
+	}
+	switch source {
+	case "inferred":
+		if hasID || hasName {
+			return fmt.Errorf("%s[%d] (%s): deploymentId/deploymentName must not be set when source is 'inferred'", field, i, action.Type)
+		}
+	default: // "selected"
+		if !hasID && !hasName {
+			return fmt.Errorf("%s[%d] (%s): exactly one of deploymentId or deploymentName must be set when source is 'selected'", field, i, action.Type)
+		}
 	}
 	return nil
 }

--- a/api/v1/prefectautomation_types_test.go
+++ b/api/v1/prefectautomation_types_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("PrefectAutomation Validate", func() {
+	// eventTrigger is a minimal valid trigger so tests can focus on action rules.
+	eventTrigger := PrefectAutomationTrigger{
+		Event: &PrefectEventTrigger{Posture: "Reactive"},
+	}
+
+	automationWithActions := func(actions ...PrefectAutomationAction) *PrefectAutomation {
+		return &PrefectAutomation{
+			Spec: PrefectAutomationSpec{
+				Name:    "a",
+				Trigger: eventTrigger,
+				Actions: actions,
+			},
+		}
+	}
+
+	Describe("trigger union", func() {
+		It("accepts exactly one trigger member", func() {
+			a := &PrefectAutomation{Spec: PrefectAutomationSpec{Name: "a", Trigger: eventTrigger}}
+			Expect(a.Validate()).To(Succeed())
+		})
+
+		It("rejects zero trigger members", func() {
+			a := &PrefectAutomation{Spec: PrefectAutomationSpec{Name: "a"}}
+			Expect(a.Validate()).To(HaveOccurred())
+		})
+
+		It("rejects more than one trigger member", func() {
+			a := &PrefectAutomation{Spec: PrefectAutomationSpec{
+				Name: "a",
+				Trigger: PrefectAutomationTrigger{
+					Event:  &PrefectEventTrigger{Posture: "Reactive"},
+					Metric: &PrefectMetricTrigger{},
+				},
+			}}
+			Expect(a.Validate()).To(HaveOccurred())
+		})
+	})
+
+	Describe("deployment target actions", func() {
+		It("rejects setting both deploymentId and deploymentName", func() {
+			a := automationWithActions(PrefectAutomationAction{
+				Type:           "run-deployment",
+				Source:         new("selected"),
+				DeploymentID:   new("dep-id"),
+				DeploymentName: new("dep-name"),
+			})
+			err := a.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("mutually exclusive"))
+		})
+
+		It("rejects both even for non-deployment action types", func() {
+			a := automationWithActions(PrefectAutomationAction{
+				Type:           "pause-automation",
+				DeploymentID:   new("dep-id"),
+				DeploymentName: new("dep-name"),
+			})
+			Expect(a.Validate()).To(HaveOccurred())
+		})
+
+		It("requires a target when source is selected", func() {
+			a := automationWithActions(PrefectAutomationAction{
+				Type:   "run-deployment",
+				Source: new("selected"),
+			})
+			err := a.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("selected"))
+		})
+
+		It("requires a target when source is unset (defaults to selected)", func() {
+			a := automationWithActions(PrefectAutomationAction{
+				Type: "run-deployment",
+			})
+			Expect(a.Validate()).To(HaveOccurred())
+		})
+
+		It("accepts a selected action with deploymentId only", func() {
+			a := automationWithActions(PrefectAutomationAction{
+				Type:         "run-deployment",
+				Source:       new("selected"),
+				DeploymentID: new("dep-id"),
+			})
+			Expect(a.Validate()).To(Succeed())
+		})
+
+		It("accepts a selected action with deploymentName only", func() {
+			a := automationWithActions(PrefectAutomationAction{
+				Type:           "pause-deployment",
+				Source:         new("selected"),
+				DeploymentName: new("dep-name"),
+			})
+			Expect(a.Validate()).To(Succeed())
+		})
+
+		It("rejects a target when source is inferred", func() {
+			a := automationWithActions(PrefectAutomationAction{
+				Type:         "run-deployment",
+				Source:       new("inferred"),
+				DeploymentID: new("dep-id"),
+			})
+			err := a.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("inferred"))
+		})
+
+		It("accepts an inferred action with no target", func() {
+			a := automationWithActions(PrefectAutomationAction{
+				Type:   "resume-deployment",
+				Source: new("inferred"),
+			})
+			Expect(a.Validate()).To(Succeed())
+		})
+
+		It("validates actions across all three lists", func() {
+			a := &PrefectAutomation{Spec: PrefectAutomationSpec{
+				Name:    "a",
+				Trigger: eventTrigger,
+				ActionsOnResolve: []PrefectAutomationAction{
+					{Type: "run-deployment", Source: new("selected")},
+				},
+			}}
+			err := a.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("actionsOnResolve"))
+		})
+	})
+
+	Describe("non-deployment actions", func() {
+		It("does not require a deployment target", func() {
+			a := automationWithActions(PrefectAutomationAction{
+				Type:    "send-notification",
+				Subject: new("hi"),
+			})
+			Expect(a.Validate()).To(Succeed())
+		})
+	})
+})

--- a/internal/controller/prefectautomation_controller.go
+++ b/internal/controller/prefectautomation_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -171,6 +172,18 @@ func (r *PrefectAutomationReconciler) syncWithPrefect(ctx context.Context, autom
 	var result *prefect.Automation
 	if automation.Status.Id != nil && *automation.Status.Id != "" {
 		result, err = prefectClient.UpdateAutomation(ctx, *automation.Status.Id, automationSpec)
+		// If the automation was deleted out-of-band, clear the stale ID and
+		// requeue so the next pass recreates it instead of looping on SyncError.
+		if errors.Is(err, prefect.ErrAutomationNotFound) {
+			log.Info("Automation no longer exists in Prefect, recreating", "automation", automation.Name, "prefectId", *automation.Status.Id)
+			automation.Status.Id = nil
+			r.setCondition(automation, PrefectAutomationConditionSynced, metav1.ConditionFalse, "Recreating", "Automation was deleted in Prefect; recreating")
+			automation.Status.Ready = false
+			if updateErr := r.Status().Update(ctx, automation); updateErr != nil {
+				log.Error(updateErr, "Failed to update automation status", "automation", automation.Name)
+			}
+			return ctrl.Result{RequeueAfter: time.Second}, nil
+		}
 	} else {
 		result, err = prefectClient.CreateAutomation(ctx, automationSpec)
 	}

--- a/internal/controller/prefectautomation_controller_test.go
+++ b/internal/controller/prefectautomation_controller_test.go
@@ -1,0 +1,340 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	prefectiov1 "github.com/PrefectHQ/prefect-operator/api/v1"
+	"github.com/PrefectHQ/prefect-operator/internal/prefect"
+)
+
+var _ = Describe("PrefectAutomation controller", func() {
+	var (
+		ctx           context.Context
+		namespace     *corev1.Namespace
+		namespaceName string
+		name          types.NamespacedName
+		automation    *prefectiov1.PrefectAutomation
+		reconciler    *PrefectAutomationReconciler
+		mockClient    *prefect.MockClient
+	)
+
+	// syncedAutomation drives the reconciler through finalizer + first sync and
+	// returns the freshly-read object.
+	syncedAutomation := func() *prefectiov1.PrefectAutomation {
+		Expect(k8sClient.Create(ctx, automation)).To(Succeed())
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+		Expect(err).NotTo(HaveOccurred())
+
+		fresh := &prefectiov1.PrefectAutomation{}
+		Expect(k8sClient.Get(ctx, name, fresh)).To(Succeed())
+		return fresh
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		namespaceName = fmt.Sprintf("automation-ns-%d", time.Now().UnixNano())
+		name = types.NamespacedName{Namespace: namespaceName, Name: "test-automation"}
+
+		namespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespaceName}}
+		Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
+
+		apiKeySecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "prefect-api-key", Namespace: namespaceName},
+			Data:       map[string][]byte{"api-key": []byte("test-api-key-value")},
+		}
+		Expect(k8sClient.Create(ctx, apiKeySecret)).To(Succeed())
+
+		automation = &prefectiov1.PrefectAutomation{
+			ObjectMeta: metav1.ObjectMeta{Name: name.Name, Namespace: name.Namespace},
+			Spec: prefectiov1.PrefectAutomationSpec{
+				Server: prefectiov1.PrefectServerReference{
+					RemoteAPIURL: new("https://api.prefect.cloud/api/accounts/abc/workspaces/def"),
+					AccountID:    new("abc-123"),
+					WorkspaceID:  new("def-456"),
+					APIKey: &prefectiov1.APIKeySpec{
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "prefect-api-key"},
+								Key:                  "api-key",
+							},
+						},
+					},
+				},
+				Name: "my-automation",
+				Trigger: prefectiov1.PrefectAutomationTrigger{
+					Event: &prefectiov1.PrefectEventTrigger{Posture: "Reactive"},
+				},
+			},
+		}
+
+		mockClient = prefect.NewMockClient()
+		reconciler = &PrefectAutomationReconciler{
+			Client:        k8sClient,
+			Scheme:        k8sClient.Scheme(),
+			PrefectClient: mockClient,
+		}
+	})
+
+	AfterEach(func() {
+		Expect(k8sClient.Delete(ctx, namespace)).To(Succeed())
+	})
+
+	It("should ignore removed PrefectAutomations", func() {
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: namespaceName, Name: "nonexistent"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+	})
+
+	Context("When reconciling a new PrefectAutomation", func() {
+		It("Should create the automation successfully", func() {
+			Expect(k8sClient.Create(ctx, automation)).To(Succeed())
+
+			By("First reconciliation - adding finalizer")
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Second))
+
+			Expect(k8sClient.Get(ctx, name, automation)).To(Succeed())
+			Expect(automation.Finalizers).To(ContainElement(PrefectAutomationFinalizer))
+
+			By("Second reconciliation - syncing with Prefect")
+			result, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(RequeueIntervalReady))
+
+			Expect(k8sClient.Get(ctx, name, automation)).To(Succeed())
+			Expect(automation.Status.Id).NotTo(BeNil())
+			_, parseErr := uuid.Parse(*automation.Status.Id)
+			Expect(parseErr).NotTo(HaveOccurred())
+			Expect(automation.Status.Ready).To(BeTrue())
+			Expect(automation.Status.SpecHash).NotTo(BeEmpty())
+			Expect(automation.Status.ObservedGeneration).To(Equal(automation.Generation))
+
+			readyCondition := meta.FindStatusCondition(automation.Status.Conditions, PrefectAutomationConditionReady)
+			Expect(readyCondition).NotTo(BeNil())
+			Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
+			syncedCondition := meta.FindStatusCondition(automation.Status.Conditions, PrefectAutomationConditionSynced)
+			Expect(syncedCondition).NotTo(BeNil())
+			Expect(syncedCondition.Status).To(Equal(metav1.ConditionTrue))
+		})
+	})
+
+	Context("When the spec is unchanged", func() {
+		It("Should not re-sync", func() {
+			fresh := syncedAutomation()
+			initialHash := fresh.Status.SpecHash
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(RequeueIntervalReady))
+
+			Expect(k8sClient.Get(ctx, name, fresh)).To(Succeed())
+			Expect(fresh.Status.SpecHash).To(Equal(initialHash))
+		})
+	})
+
+	Context("When the spec changes", func() {
+		It("Should detect the change and re-sync", func() {
+			fresh := syncedAutomation()
+			initialID := *fresh.Status.Id
+
+			fresh.Spec.Description = new("updated")
+			Expect(k8sClient.Update(ctx, fresh)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(RequeueIntervalReady))
+
+			Expect(k8sClient.Get(ctx, name, fresh)).To(Succeed())
+			Expect(fresh.Status.Ready).To(BeTrue())
+			// Update path keeps the same ID.
+			Expect(*fresh.Status.Id).To(Equal(initialID))
+		})
+	})
+
+	Context("When the spec is invalid", func() {
+		It("Should set InvalidSpec when no trigger is set", func() {
+			automation.Spec.Trigger = prefectiov1.PrefectAutomationTrigger{}
+			Expect(k8sClient.Create(ctx, automation)).To(Succeed())
+
+			// Finalizer pass.
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+
+			Expect(k8sClient.Get(ctx, name, automation)).To(Succeed())
+			Expect(automation.Status.Ready).To(BeFalse())
+			cond := meta.FindStatusCondition(automation.Status.Conditions, PrefectAutomationConditionSynced)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Reason).To(Equal("InvalidSpec"))
+		})
+
+		It("Should set InvalidSpec when an action sets both deploymentId and deploymentName", func() {
+			automation.Spec.Actions = []prefectiov1.PrefectAutomationAction{
+				{
+					Type:           "run-deployment",
+					Source:         new("selected"),
+					DeploymentID:   new("dep-id"),
+					DeploymentName: new("dep-name"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, automation)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, name, automation)).To(Succeed())
+			cond := meta.FindStatusCondition(automation.Status.Conditions, PrefectAutomationConditionSynced)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Reason).To(Equal("InvalidSpec"))
+		})
+	})
+
+	Context("When an action references a deployment by name", func() {
+		BeforeEach(func() {
+			automation.Spec.Actions = []prefectiov1.PrefectAutomationAction{
+				{Type: "run-deployment", Source: new("selected"), DeploymentName: new("daily-etl")},
+			}
+		})
+
+		It("Should requeue until the deployment exists, then sync", func() {
+			Expect(k8sClient.Create(ctx, automation)).To(Succeed())
+
+			By("Finalizer pass")
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Deployment not found yet - requeue")
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(5 * time.Second))
+
+			Expect(k8sClient.Get(ctx, name, automation)).To(Succeed())
+			Expect(automation.Status.Ready).To(BeFalse())
+			cond := meta.FindStatusCondition(automation.Status.Conditions, PrefectAutomationConditionSynced)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Reason).To(Equal("DeploymentNotFound"))
+
+			By("Seeding the deployment into Prefect")
+			_, err = mockClient.CreateOrUpdateDeployment(ctx, &prefect.DeploymentSpec{Name: "daily-etl", FlowID: "flow-1"})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Now it resolves and syncs")
+			result, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(RequeueIntervalReady))
+
+			Expect(k8sClient.Get(ctx, name, automation)).To(Succeed())
+			Expect(automation.Status.Id).NotTo(BeNil())
+			Expect(automation.Status.Ready).To(BeTrue())
+		})
+	})
+
+	Context("When the automation is deleted out-of-band in Prefect", func() {
+		It("Should clear the stale ID and recreate rather than loop on SyncError", func() {
+			fresh := syncedAutomation()
+			originalID := *fresh.Status.Id
+
+			By("Deleting the automation directly in Prefect")
+			Expect(mockClient.DeleteAutomation(ctx, originalID)).To(Succeed())
+
+			By("Changing the spec to force a sync")
+			fresh.Spec.Description = new("changed")
+			Expect(k8sClient.Update(ctx, fresh)).To(Succeed())
+
+			By("Reconcile detects the 404 and clears the ID")
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Second))
+
+			Expect(k8sClient.Get(ctx, name, fresh)).To(Succeed())
+			Expect(fresh.Status.Id).To(BeNil())
+
+			By("Next reconcile recreates the automation")
+			result, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(RequeueIntervalReady))
+
+			Expect(k8sClient.Get(ctx, name, fresh)).To(Succeed())
+			Expect(fresh.Status.Id).NotTo(BeNil())
+			Expect(*fresh.Status.Id).NotTo(Equal(originalID))
+			Expect(fresh.Status.Ready).To(BeTrue())
+		})
+	})
+
+	Context("When Prefect returns a sync error", func() {
+		It("Should set SyncError and requeue on the error interval", func() {
+			mockClient.ShouldFailCreate = true
+			mockClient.FailureMessage = "simulated Prefect API error"
+
+			Expect(k8sClient.Create(ctx, automation)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(RequeueIntervalError))
+
+			Expect(k8sClient.Get(ctx, name, automation)).To(Succeed())
+			cond := meta.FindStatusCondition(automation.Status.Conditions, PrefectAutomationConditionSynced)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Reason).To(Equal("SyncError"))
+		})
+	})
+
+	Context("When the automation is deleted", func() {
+		It("Should clean up from Prefect and remove the finalizer", func() {
+			fresh := syncedAutomation()
+			Expect(fresh.Status.Id).NotTo(BeNil())
+
+			Expect(k8sClient.Delete(ctx, fresh)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = k8sClient.Get(ctx, name, fresh)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+	})
+})

--- a/internal/prefect/automation.go
+++ b/internal/prefect/automation.go
@@ -20,11 +20,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"time"
 )
+
+// ErrAutomationNotFound is returned when an automation no longer exists in
+// Prefect (e.g. it was deleted out-of-band). Callers can use errors.Is to
+// distinguish this from other API errors and recreate rather than loop.
+var ErrAutomationNotFound = errors.New("automation not found")
 
 // AutomationSpec is the request payload for creating/updating an automation.
 // Trigger and actions are kept as generic maps so the client stays agnostic to
@@ -160,6 +166,10 @@ func (c *Client) UpdateAutomation(ctx context.Context, id string, automation *Au
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
+	// A 404 means the automation was deleted out-of-band; signal recreate.
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrAutomationNotFound
+	}
 	if !isSuccessStatusCode(resp.StatusCode) {
 		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
 	}
@@ -169,9 +179,10 @@ func (c *Client) UpdateAutomation(ctx context.Context, id string, automation *Au
 }
 
 // FindDeploymentByName resolves a deployment by name (tenant-wide) via
-// POST /deployments/filter. Errors if no deployment matches; if several share
-// the name it returns the first (deployment names are unique per flow, and in
-// practice unique across our pipelines).
+// POST /deployments/filter. Deployment names are only unique per flow (the
+// canonical reference is "{flow}/{deployment}"), so a bare name can match more
+// than one deployment. Errors if no deployment matches, and errors if the name
+// is ambiguous (>1 match) rather than silently resolving to an arbitrary one.
 func (c *Client) FindDeploymentByName(ctx context.Context, name string) (*Deployment, error) {
 	url := fmt.Sprintf("%s/deployments/filter", c.BaseURL)
 	c.log.V(1).Info("Finding deployment by name", "url", url, "name", name)
@@ -180,7 +191,7 @@ func (c *Client) FindDeploymentByName(ctx context.Context, name string) (*Deploy
 		"deployments": map[string]any{
 			keyName: map[string]any{"any_": []string{name}},
 		},
-		"limit": 1,
+		"limit": 2,
 	}
 	jsonData, err := json.Marshal(filter)
 	if err != nil {
@@ -213,6 +224,9 @@ func (c *Client) FindDeploymentByName(ctx context.Context, name string) (*Deploy
 	}
 	if len(results) == 0 {
 		return nil, fmt.Errorf("no deployment found with name %q", name)
+	}
+	if len(results) > 1 {
+		return nil, fmt.Errorf("deployment name %q is ambiguous: it matches multiple deployments (names are only unique per flow); use a flow-qualified reference", name)
 	}
 	return &results[0], nil
 }

--- a/internal/prefect/automation_test.go
+++ b/internal/prefect/automation_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prefect
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Automation client", func() {
+	var (
+		ctx        context.Context
+		client     *Client
+		mockServer *httptest.Server
+		logger     logr.Logger
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		logger = logr.Discard()
+	})
+
+	AfterEach(func() {
+		if mockServer != nil {
+			mockServer.Close()
+		}
+	})
+
+	Describe("UpdateAutomation", func() {
+		It("returns ErrAutomationNotFound on a 404", func() {
+			mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer GinkgoRecover()
+				Expect(r.Method).To(Equal(http.MethodPut))
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			client = NewClient(mockServer.URL, "", logger)
+
+			_, err := client.UpdateAutomation(ctx, "missing-id", &AutomationSpec{Name: "a"})
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, ErrAutomationNotFound)).To(BeTrue())
+		})
+
+		It("returns a generic error on other non-2xx statuses", func() {
+			mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer GinkgoRecover()
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			client = NewClient(mockServer.URL, "", logger)
+
+			_, err := client.UpdateAutomation(ctx, "some-id", &AutomationSpec{Name: "a"})
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, ErrAutomationNotFound)).To(BeFalse())
+		})
+	})
+
+	Describe("FindDeploymentByName", func() {
+		It("resolves a unique name", func() {
+			mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer GinkgoRecover()
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode([]Deployment{{ID: "dep-1", Name: "daily-etl"}})
+			}))
+			client = NewClient(mockServer.URL, "", logger)
+
+			dep, err := client.FindDeploymentByName(ctx, "daily-etl")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dep.ID).To(Equal("dep-1"))
+		})
+
+		It("errors when the name matches no deployment", func() {
+			mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer GinkgoRecover()
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode([]Deployment{})
+			}))
+			client = NewClient(mockServer.URL, "", logger)
+
+			_, err := client.FindDeploymentByName(ctx, "nope")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no deployment found"))
+		})
+
+		It("errors when the name is ambiguous across flows", func() {
+			mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer GinkgoRecover()
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode([]Deployment{
+					{ID: "dep-1", Name: "daily-etl", FlowID: "flow-a"},
+					{ID: "dep-2", Name: "daily-etl", FlowID: "flow-b"},
+				})
+			}))
+			client = NewClient(mockServer.URL, "", logger)
+
+			_, err := client.FindDeploymentByName(ctx, "daily-etl")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ambiguous"))
+		})
+	})
+})

--- a/internal/prefect/convert_automation.go
+++ b/internal/prefect/convert_automation.go
@@ -275,10 +275,18 @@ func buildAction(a prefectiov1.PrefectAutomationAction, deploymentIDs map[string
 	putStr("subject", a.Subject)
 	putStr("body", a.Body)
 	putStr("payload", a.Payload)
-	if params, err := rawToMap(a.Parameters); err == nil && a.Parameters != nil {
+	if a.Parameters != nil {
+		params, err := rawToMap(a.Parameters)
+		if err != nil {
+			return nil, fmt.Errorf("action parameters: %w", err)
+		}
 		m["parameters"] = params
 	}
-	if jv, err := rawToMap(a.JobVariables); err == nil && a.JobVariables != nil {
+	if a.JobVariables != nil {
+		jv, err := rawToMap(a.JobVariables)
+		if err != nil {
+			return nil, fmt.Errorf("action job_variables: %w", err)
+		}
 		m["job_variables"] = jv
 	}
 	return m, nil

--- a/internal/prefect/convert_automation_test.go
+++ b/internal/prefect/convert_automation_test.go
@@ -163,4 +163,36 @@ var _ = Describe("ConvertToAutomationSpec", func() {
 		_, err := ConvertToAutomationSpec(a, map[string]string{})
 		Expect(err).To(HaveOccurred())
 	})
+
+	It("propagates invalid JSON in action parameters", func() {
+		a := newAutomation(prefectiov1.PrefectAutomationTrigger{
+			Event: &prefectiov1.PrefectEventTrigger{Posture: "Reactive"},
+		})
+		a.Spec.Actions = []prefectiov1.PrefectAutomationAction{
+			{
+				Type:       "run-deployment",
+				Source:     ptr("inferred"),
+				Parameters: &runtime.RawExtension{Raw: []byte(`{"bad": json}`)},
+			},
+		}
+		_, err := ConvertToAutomationSpec(a, nil)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("parameters"))
+	})
+
+	It("propagates invalid JSON in action jobVariables", func() {
+		a := newAutomation(prefectiov1.PrefectAutomationTrigger{
+			Event: &prefectiov1.PrefectEventTrigger{Posture: "Reactive"},
+		})
+		a.Spec.Actions = []prefectiov1.PrefectAutomationAction{
+			{
+				Type:         "run-deployment",
+				Source:       ptr("inferred"),
+				JobVariables: &runtime.RawExtension{Raw: []byte(`{"bad": json}`)},
+			},
+		}
+		_, err := ConvertToAutomationSpec(a, nil)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("job_variables"))
+	})
 })

--- a/internal/prefect/mock.go
+++ b/internal/prefect/mock.go
@@ -101,7 +101,7 @@ func (m *MockClient) UpdateAutomation(ctx context.Context, id string, automation
 	defer m.mu.Unlock()
 	existing, ok := m.automations[id]
 	if !ok {
-		return nil, fmt.Errorf("automation %s not found", id)
+		return nil, fmt.Errorf("automation %s: %w", id, ErrAutomationNotFound)
 	}
 	existing.Name = automation.Name
 	existing.Description = automation.Description


### PR DESCRIPTION
## What

Follow-up hardening for the `PrefectAutomation` CRD + controller merged in #294. None of these were blockers, but worth addressing before the CRD sees real use.

- **Self-heal on out-of-band delete** — if the automation is deleted directly in Prefect, `UpdateAutomation` returned a generic error and the controller looped on `SyncError` forever. A 404 on update now surfaces as a sentinel (`ErrAutomationNotFound`); the controller clears the stored ID and recreates on the next pass.
- **Propagate JSON errors** — invalid `parameters` / `jobVariables` JSON in an action was silently dropped, unlike the `match` / `matchRelated` paths. It now returns the error.
- **Enforce deploymentId / deploymentName rules in `Validate()`** — the two are mutually exclusive, and for `run/pause/resume-deployment` the presence of a target is governed by `source`. This mirrors the Prefect API schema: `"selected"` (the default) requires exactly one target, `"inferred"` requires none.
- **Error on ambiguous deployment names** — `FindDeploymentByName` used `limit:1` + first result, so a bare name matching multiple deployments resolved arbitrarily. Deployment names are only unique per flow (canonical reference is `{flow}/{deployment}`), so it now errors on `>1` match instead of picking one silently.
- **Tests** — adds the missing controller envtest suite plus unit coverage for each item above.

## Notes

Full flow-qualified (`flowName/deploymentName`) reference support is a larger CRD change and is left as a follow-up. This PR just makes the ambiguous case fail loudly instead of mis-resolving.

No API-shape changes, so the generated CRD / deepcopy / docs are unchanged.

Related to #294

<details>
<summary>Session context</summary>

Started from a follow-up review of #294 that listed five hardening items. The two low-confidence decisions (how to handle duplicate deployment names, and whether a target is always required for deployment actions) were resolved against the Prefect API schema and docs rather than guessed: deployment names are unique only per flow, and the `source` field defaults to `"selected"` which requires a target while `"inferred"` forbids one.

Verified with `make test` (all suites green, including the new controller specs), `make lint` (clean), and `make manifests generate` (no drift).
</details>