### PR TITLE
fix: re-sync PrefectAutomation every reconcile for continuous self-heal

### DIFF
--- a/internal/controller/prefectautomation_needssync_test.go
+++ b/internal/controller/prefectautomation_needssync_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	prefectiov1 "github.com/PrefectHQ/prefect-operator/api/v1"
+)
+
+// UpdateAutomationStatus never stamps LastSyncTime, so needsSync sees a nil
+// LastSyncTime on every pass and returns true — the controller reconciles
+// against Prefect each loop and self-heals an out-of-band edit/delete within one
+// requeue interval, matching PrefectDeployment's continuous reconcile.
+func TestAutomationNeedsSync(t *testing.T) {
+	r := &PrefectAutomationReconciler{}
+	id := "automation-1"
+	hash := "hash-1"
+
+	// Steady state as persisted by UpdateAutomationStatus: id + spec hash +
+	// observed generation set, but LastSyncTime left nil.
+	steady := &prefectiov1.PrefectAutomation{}
+	steady.Generation = 2
+	steady.Status.Id = &id
+	steady.Status.SpecHash = hash
+	steady.Status.ObservedGeneration = 2
+
+	if !r.needsSync(steady, hash) {
+		t.Fatal("needsSync = false in steady state; want true so out-of-band changes self-heal every loop")
+	}
+}

--- a/internal/prefect/convert_automation.go
+++ b/internal/prefect/convert_automation.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strconv"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	prefectiov1 "github.com/PrefectHQ/prefect-operator/api/v1"
@@ -304,10 +303,16 @@ func nonNilStrings(s []string) []string {
 }
 
 // UpdateAutomationStatus updates the K8s PrefectAutomation status from an API Automation.
+//
+// LastSyncTime is deliberately NOT stamped: needsSync treats a nil LastSyncTime
+// as "sync now", so leaving it unset makes the controller reconcile against
+// Prefect on every pass and self-heal an out-of-band edit/delete within one
+// requeue interval — matching PrefectDeployment, whose status likewise carries
+// no LastSyncTime. Persisting it here previously gated re-sync behind a 10-minute
+// drift window, so a manual change in Prefect wasn't corrected until then (or an
+// operator restart).
 func UpdateAutomationStatus(k8sAutomation *prefectiov1.PrefectAutomation, automation *Automation) {
 	id := automation.ID
 	k8sAutomation.Status.Id = &id
 	k8sAutomation.Status.Ready = true
-	now := metav1.Now()
-	k8sAutomation.Status.LastSyncTime = &now
 }

--- a/internal/prefect/convert_automation_lastsync_test.go
+++ b/internal/prefect/convert_automation_lastsync_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prefect
+
+import (
+	"testing"
+
+	prefectiov1 "github.com/PrefectHQ/prefect-operator/api/v1"
+)
+
+// UpdateAutomationStatus must set Id/Ready but leave LastSyncTime nil: needsSync
+// treats a nil LastSyncTime as "sync now", so this is what makes the controller
+// reconcile against Prefect every pass and self-heal an out-of-band edit/delete
+// (parity with PrefectDeployment, whose status also carries no LastSyncTime).
+func TestUpdateAutomationStatusLeavesLastSyncTimeNil(t *testing.T) {
+	k8s := &prefectiov1.PrefectAutomation{}
+	UpdateAutomationStatus(k8s, &Automation{ID: "abc"})
+
+	if k8s.Status.Id == nil || *k8s.Status.Id != "abc" {
+		t.Fatalf("Status.Id = %v, want \"abc\"", k8s.Status.Id)
+	}
+	if !k8s.Status.Ready {
+		t.Fatal("Status.Ready = false, want true")
+	}
+	if k8s.Status.LastSyncTime != nil {
+		t.Fatal("Status.LastSyncTime must stay nil so the controller re-syncs every reconcile")
+	}
+}


### PR DESCRIPTION
## What

`PrefectAutomation` persisted `Status.LastSyncTime`, so `needsSync` short-circuited on a **10-minute drift timer** and never re-checked Prefect in between reconciles. A manual edit or delete of the automation in the Prefect UI/API was not reconciled back until the drift window elapsed or the operator restarted.

`PrefectDeployment` reconciles against Prefect on **every** pass (its status carries no `LastSyncTime`), so it self-heals out-of-band changes continuously. This aligns `PrefectAutomation` with that behavior: `needsSync` now returns `true` each reconcile. `syncWithPrefect` is idempotent (update-in-place), so re-running it every pass is safe.

## Why it was observable

With the drift gate, a deleted automation showed only the `Reconciling` debug line every ~10s and never came back until a restart — even though the CR was `Ready`. After this change the controller re-checks each loop and re-applies desired state.

## Relationship to #297

Complementary. #297 makes the **delete** case recreate (surfaces a 404 on update as a sentinel → recreate). This PR fixes the **cadence** so that recreate (and any drift/edit correction) happens within one requeue interval instead of only on the 10-minute drift. Together they give prompt, continuous self-heal. This PR is orthogonal to #297 (it does not touch `syncWithPrefect`/`UpdateAutomation`) and can merge independently.

## Test

Adds `TestAutomationNeedsSync` — a unit test asserting `needsSync` returns `true` in steady state (id set, spec hash unchanged, generation observed, just synced), which was `false` before.

Related to #294, #297.