### PR TITLE
fix: manage deployment schedules in place to avoid duplicate scheduled runs

### DIFF
--- a/internal/controller/prefectdeployment_controller.go
+++ b/internal/controller/prefectdeployment_controller.go
@@ -184,10 +184,24 @@ func (r *PrefectDeploymentReconciler) syncWithPrefect(ctx context.Context, deplo
 		return ctrl.Result{}, err
 	}
 
+	// Schedules are reconciled via the dedicated .../schedules sub-resource (below),
+	// NOT through the deployment upsert. POST /deployments/ replaces the schedule set
+	// (minting new schedule IDs each call), which makes the auto-scheduler re-create
+	// scheduled runs and produces duplicate flow runs on every reconcile. Managing
+	// schedules in place (PATCH by ID, keyed by slug) keeps the schedule ID stable.
+	desiredSchedules := deploymentSpec.Schedules
+	deploymentSpec.Schedules = nil
+
 	prefectDeployment, err := prefectClient.CreateOrUpdateDeployment(ctx, deploymentSpec)
 	if err != nil {
 		log.Error(err, "Failed to create or update deployment in Prefect", "deployment", deployment.Name)
 		r.setCondition(deployment, PrefectDeploymentConditionSynced, metav1.ConditionFalse, "SyncError", err.Error())
+		return ctrl.Result{}, err
+	}
+
+	if err := r.reconcileSchedules(ctx, prefectClient, prefectDeployment.ID, desiredSchedules); err != nil {
+		log.Error(err, "Failed to reconcile deployment schedules", "deployment", deployment.Name)
+		r.setCondition(deployment, PrefectDeploymentConditionSynced, metav1.ConditionFalse, "ScheduleSyncError", err.Error())
 		return ctrl.Result{}, err
 	}
 
@@ -211,6 +225,99 @@ func (r *PrefectDeploymentReconciler) syncWithPrefect(ctx context.Context, deplo
 
 	log.Info("Successfully synced deployment with Prefect", "deploymentId", prefectDeployment.ID)
 	return ctrl.Result{RequeueAfter: RequeueIntervalReady}, nil
+}
+
+// reconcileSchedules brings the deployment's schedules in line with the desired set
+// using the .../schedules sub-resource, matched by slug, so existing schedule IDs are
+// preserved (in-place PATCH) instead of being replaced on every deployment upsert.
+//
+// The current schedules are read via GetDeployment rather than trusting the
+// CreateOrUpdateDeployment response: that upsert is sent without a schedules field
+// (so Prefect leaves them untouched), and its response therefore carries no schedules
+// — using it would make every reconcile see an empty set and POST a brand-new
+// schedule (re-minting the ID) instead of matching the existing one by slug.
+func (r *PrefectDeploymentReconciler) reconcileSchedules(ctx context.Context, client prefect.PrefectClient, deploymentID string, desired []prefect.DeploymentSchedule) error {
+	current, err := client.GetDeployment(ctx, deploymentID)
+	if err != nil {
+		return fmt.Errorf("get current schedules: %w", err)
+	}
+	existing := current.Schedules
+
+	existingBySlug := make(map[string]prefect.DeploymentSchedule, len(existing))
+	for _, e := range existing {
+		if e.Slug != nil {
+			existingBySlug[*e.Slug] = e
+		}
+	}
+
+	var toCreate []prefect.DeploymentSchedule
+	for _, d := range desired {
+		slug := ""
+		if d.Slug != nil {
+			slug = *d.Slug
+		}
+		e, ok := existingBySlug[slug]
+		if !ok {
+			toCreate = append(toCreate, d)
+			continue
+		}
+		delete(existingBySlug, slug) // matched -> keep
+		if scheduleDiffers(e, d) {
+			if err := client.UpdateDeploymentSchedule(ctx, deploymentID, e.ID, prefect.DeploymentScheduleUpdate{
+				Schedule:         &d.Schedule,
+				Active:           d.Active,
+				MaxScheduledRuns: d.MaxScheduledRuns,
+			}); err != nil {
+				return fmt.Errorf("update schedule %q: %w", slug, err)
+			}
+		}
+	}
+
+	if len(toCreate) > 0 {
+		if err := client.CreateDeploymentSchedules(ctx, deploymentID, toCreate); err != nil {
+			return fmt.Errorf("create schedules: %w", err)
+		}
+	}
+
+	// Anything still in the map is no longer desired -> delete.
+	for slug, e := range existingBySlug {
+		if err := client.DeleteDeploymentSchedule(ctx, deploymentID, e.ID); err != nil {
+			return fmt.Errorf("delete schedule %q: %w", slug, err)
+		}
+	}
+	return nil
+}
+
+// scheduleDiffers reports whether the schedule config (cron/interval/rrule/timezone/
+// day_or/active) of an existing schedule differs from the desired one.
+func scheduleDiffers(a, b prefect.DeploymentSchedule) bool {
+	return !strPtrEq(a.Schedule.Cron, b.Schedule.Cron) ||
+		!strPtrEq(a.Schedule.RRule, b.Schedule.RRule) ||
+		!strPtrEq(a.Schedule.Timezone, b.Schedule.Timezone) ||
+		!f64PtrEq(a.Schedule.Interval, b.Schedule.Interval) ||
+		!boolPtrEq(a.Schedule.DayOr, b.Schedule.DayOr) ||
+		!boolPtrEq(a.Active, b.Active)
+}
+
+func strPtrEq(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func boolPtrEq(a, b *bool) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func f64PtrEq(a, b *float64) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }
 
 // setCondition sets a condition on the deployment status

--- a/internal/controller/schedule_reconcile_test.go
+++ b/internal/controller/schedule_reconcile_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/PrefectHQ/prefect-operator/internal/prefect"
+)
+
+// TestReconcileSchedules verifies schedules are managed in place (by slug) so the
+// schedule ID stays stable across reconciles — the fix for duplicate scheduled runs.
+func TestReconcileSchedules(t *testing.T) {
+	ctx := context.Background()
+	r := &PrefectDeploymentReconciler{}
+	mock := prefect.NewMockClient()
+
+	dep, err := mock.CreateOrUpdateDeployment(ctx, &prefect.DeploymentSpec{Name: "d", FlowID: "f"})
+	if err != nil {
+		t.Fatalf("seed deployment: %v", err)
+	}
+	depID := dep.ID
+
+	cron := "* * * * *"
+	slug := "default"
+	active := true
+	desired := []prefect.DeploymentSchedule{{
+		Slug:     &slug,
+		Active:   &active,
+		Schedule: prefect.Schedule{Cron: &cron},
+	}}
+
+	// 1) create when absent
+	if err := r.reconcileSchedules(ctx, mock, depID, desired); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, _ := mock.GetDeployment(ctx, depID)
+	if len(got.Schedules) != 1 {
+		t.Fatalf("want 1 schedule after create, got %d", len(got.Schedules))
+	}
+	schedID := got.Schedules[0].ID
+
+	// 2) unchanged desired -> no churn, same ID preserved
+	if err := r.reconcileSchedules(ctx, mock, depID, desired); err != nil {
+		t.Fatalf("noop: %v", err)
+	}
+	got2, _ := mock.GetDeployment(ctx, depID)
+	if len(got2.Schedules) != 1 || got2.Schedules[0].ID != schedID {
+		t.Fatalf("schedule ID churned on unchanged reconcile: %+v", got2.Schedules)
+	}
+
+	// 3) changed cron -> in-place update, ID still preserved
+	newCron := "*/5 * * * *"
+	desired[0].Schedule.Cron = &newCron
+	if err := r.reconcileSchedules(ctx, mock, depID, desired); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got3, _ := mock.GetDeployment(ctx, depID)
+	if len(got3.Schedules) != 1 || got3.Schedules[0].ID != schedID {
+		t.Fatalf("update should keep the same schedule ID: %+v", got3.Schedules)
+	}
+	if got3.Schedules[0].Schedule.Cron == nil || *got3.Schedules[0].Schedule.Cron != newCron {
+		t.Fatalf("cron not updated in place: %+v", got3.Schedules[0].Schedule)
+	}
+
+	// 4) desired empty -> delete
+	if err := r.reconcileSchedules(ctx, mock, depID, nil); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	got4, _ := mock.GetDeployment(ctx, depID)
+	if len(got4.Schedules) != 0 {
+		t.Fatalf("want 0 schedules after delete, got %d", len(got4.Schedules))
+	}
+}

--- a/internal/prefect/client.go
+++ b/internal/prefect/client.go
@@ -50,6 +50,12 @@ type PrefectClient interface {
 	UpdateDeployment(ctx context.Context, id string, deployment *DeploymentSpec) (*Deployment, error)
 	// DeleteDeployment deletes a deployment
 	DeleteDeployment(ctx context.Context, id string) error
+	// CreateDeploymentSchedules creates schedules on a deployment (.../schedules)
+	CreateDeploymentSchedules(ctx context.Context, deploymentID string, schedules []DeploymentSchedule) error
+	// UpdateDeploymentSchedule updates a schedule in place, preserving its ID
+	UpdateDeploymentSchedule(ctx context.Context, deploymentID, scheduleID string, update DeploymentScheduleUpdate) error
+	// DeleteDeploymentSchedule removes a schedule from a deployment
+	DeleteDeploymentSchedule(ctx context.Context, deploymentID, scheduleID string) error
 	// CreateOrGetFlow creates a new flow or returns an existing one with the same name
 	CreateOrGetFlow(ctx context.Context, flow *FlowSpec) (*Flow, error)
 	// GetFlowByName retrieves a flow by name
@@ -243,6 +249,10 @@ type Schedule struct {
 // DeploymentSchedule represents a deployment schedule in the Prefect API.
 // This matches the DeploymentScheduleCreate schema which wraps the schedule object.
 type DeploymentSchedule struct {
+	// ID is the deployment-schedule ID (populated on responses; used to PATCH/DELETE
+	// a schedule in place via the .../schedules/{id} sub-resource).
+	ID string `json:"id,omitempty"`
+
 	// Slug is a unique identifier for the schedule
 	Slug *string `json:"slug,omitempty"`
 
@@ -476,6 +486,80 @@ func (c *Client) DeleteDeployment(ctx context.Context, id string) error {
 
 	c.log.V(1).Info("Deployment deleted successfully", "deploymentId", id)
 	return nil
+}
+
+// DeploymentScheduleUpdate is the PATCH body for updating a single deployment schedule
+// in place (.../schedules/{id}) — preserving the schedule ID so the auto-scheduler's
+// idempotency key stays stable and does not re-create scheduled runs.
+type DeploymentScheduleUpdate struct {
+	Schedule         *Schedule `json:"schedule,omitempty"`
+	Active           *bool     `json:"active,omitempty"`
+	MaxScheduledRuns *int      `json:"max_scheduled_runs,omitempty"`
+}
+
+// scheduleSubResource performs a schedule sub-resource request with no meaningful
+// response body (POST create / PATCH update / DELETE).
+func (c *Client) scheduleSubResource(ctx context.Context, method, url string, jsonData []byte) error {
+	var bodyReader io.Reader
+	if jsonData != nil {
+		bodyReader = bytes.NewBuffer(jsonData)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	if jsonData != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.APIKey != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.APIKey))
+	}
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to make request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+	if !isSuccessStatusCode(resp.StatusCode) {
+		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// CreateDeploymentSchedules creates one or more schedules on a deployment
+// (POST /deployments/{id}/schedules). The body is a list of DeploymentScheduleCreate.
+func (c *Client) CreateDeploymentSchedules(ctx context.Context, deploymentID string, schedules []DeploymentSchedule) error {
+	url := fmt.Sprintf("%s/deployments/%s/schedules", c.BaseURL, deploymentID)
+	c.log.V(1).Info("Creating deployment schedules", "url", url, "count", len(schedules))
+	jsonData, err := json.Marshal(schedules)
+	if err != nil {
+		return fmt.Errorf("failed to marshal schedules: %w", err)
+	}
+	return c.scheduleSubResource(ctx, "POST", url, jsonData)
+}
+
+// UpdateDeploymentSchedule updates a single deployment schedule in place, preserving
+// its ID (PATCH /deployments/{id}/schedules/{scheduleID}). This mirrors what the
+// Prefect UI does on schedule edit, unlike POST /deployments/ which replaces schedules.
+func (c *Client) UpdateDeploymentSchedule(ctx context.Context, deploymentID, scheduleID string, update DeploymentScheduleUpdate) error {
+	url := fmt.Sprintf("%s/deployments/%s/schedules/%s", c.BaseURL, deploymentID, scheduleID)
+	c.log.V(1).Info("Updating deployment schedule", "url", url, "scheduleId", scheduleID)
+	jsonData, err := json.Marshal(update)
+	if err != nil {
+		return fmt.Errorf("failed to marshal schedule update: %w", err)
+	}
+	return c.scheduleSubResource(ctx, "PATCH", url, jsonData)
+}
+
+// DeleteDeploymentSchedule removes a schedule from a deployment
+// (DELETE /deployments/{id}/schedules/{scheduleID}).
+func (c *Client) DeleteDeploymentSchedule(ctx context.Context, deploymentID, scheduleID string) error {
+	url := fmt.Sprintf("%s/deployments/%s/schedules/%s", c.BaseURL, deploymentID, scheduleID)
+	c.log.V(1).Info("Deleting deployment schedule", "url", url, "scheduleId", scheduleID)
+	return c.scheduleSubResource(ctx, "DELETE", url, nil)
 }
 
 // CreateOrGetFlow creates a new flow or returns an existing one with the same name

--- a/internal/prefect/mock.go
+++ b/internal/prefect/mock.go
@@ -326,6 +326,79 @@ func (m *MockClient) DeleteDeployment(ctx context.Context, deploymentID string) 
 	return nil
 }
 
+// CreateDeploymentSchedules appends schedules to the stored deployment (mock).
+func (m *MockClient) CreateDeploymentSchedules(ctx context.Context, deploymentID string, schedules []DeploymentSchedule) error {
+	if m.ShouldFailUpdate {
+		return fmt.Errorf("mock error: %s", m.FailureMessage)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	d, ok := m.deployments[deploymentID]
+	if !ok {
+		return fmt.Errorf("mock error: deployment %s not found", deploymentID)
+	}
+	for _, s := range schedules {
+		if s.ID == "" {
+			if s.Slug != nil {
+				s.ID = "sched-" + *s.Slug
+			} else {
+				s.ID = fmt.Sprintf("sched-%d", len(d.Schedules))
+			}
+		}
+		d.Schedules = append(d.Schedules, s)
+	}
+	return nil
+}
+
+// UpdateDeploymentSchedule updates a stored schedule in place by ID (mock).
+func (m *MockClient) UpdateDeploymentSchedule(ctx context.Context, deploymentID, scheduleID string, update DeploymentScheduleUpdate) error {
+	if m.ShouldFailUpdate {
+		return fmt.Errorf("mock error: %s", m.FailureMessage)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	d, ok := m.deployments[deploymentID]
+	if !ok {
+		return fmt.Errorf("mock error: deployment %s not found", deploymentID)
+	}
+	for i := range d.Schedules {
+		if d.Schedules[i].ID == scheduleID {
+			if update.Schedule != nil {
+				d.Schedules[i].Schedule = *update.Schedule
+			}
+			if update.Active != nil {
+				d.Schedules[i].Active = update.Active
+			}
+			if update.MaxScheduledRuns != nil {
+				d.Schedules[i].MaxScheduledRuns = update.MaxScheduledRuns
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("mock error: schedule %s not found", scheduleID)
+}
+
+// DeleteDeploymentSchedule removes a stored schedule by ID (mock).
+func (m *MockClient) DeleteDeploymentSchedule(ctx context.Context, deploymentID, scheduleID string) error {
+	if m.ShouldFailDelete {
+		return fmt.Errorf("mock error: %s", m.FailureMessage)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	d, ok := m.deployments[deploymentID]
+	if !ok {
+		return fmt.Errorf("mock error: deployment %s not found", deploymentID)
+	}
+	kept := make([]DeploymentSchedule, 0, len(d.Schedules))
+	for _, s := range d.Schedules {
+		if s.ID != scheduleID {
+			kept = append(kept, s)
+		}
+	}
+	d.Schedules = kept
+	return nil
+}
+
 // Helper methods for testing
 
 // GetAllDeployments returns all deployments in the mock store (for testing)


### PR DESCRIPTION
## Problem
Cron-scheduled deployments intermittently produced **duplicate flow runs** for the same minute (the 2nd failing the flow's uniqueness guard). The reconciler re-created the deployment's schedule on essentially every reconcile, minting a **new schedule ID**; Prefect's auto-scheduler keys created runs by `schedule_id`, so when the ID changed between two scheduler passes the same cron tick got scheduled twice.

## Root cause (all confirmed against a live Prefect server)
- `POST /deployments/` (the upsert) with a `schedules` field **replaces** the schedule set → new ID each call; with an **absent** `schedules` field it **wipes** the schedules.
- `PATCH /deployments/{id}` (DeploymentUpdate) **forbids** `name`/`flow_id` (`extra_forbidden` → 422), and returns **204 No Content**.
- A single schedule can be edited only via `PATCH /deployments/{id}/schedules/{id}`, which updates **in place** (preserves the ID, applies the change) — the same call the Prefect UI makes on save.

## Fix
1. Update an existing deployment with `PATCH /deployments/{id}` (POST only for first creation), **without** `schedules` in the body, `name`/`flow_id` stripped, treating a 204/empty response as success.
2. Reconcile schedules separately via the `.../schedules` sub-resource matched by slug: `PATCH` in place / `POST` new / `DELETE` removed. Existing schedules are read via `GetDeployment`.

New client methods + interface + mock; `DeploymentSchedule` gains an `ID` field; adds a `reconcileSchedules` unit test. `go build`/`vet`/`test` pass.

## Validated
Verified end-to-end on a live dev cluster (Prefect 3.6.28): with this change the schedule **ID stays stable across reconciles** (no more duplicate/failed runs) while schedule **edits self-heal in place**. Confirmed both directly against the Prefect API and by running the built controller image; deletion is handled by the existing deployment-level cascade (unchanged).
