### PR TITLE
fix: manage deployment schedules in place to avoid duplicate scheduled runs

### DIFF
--- a/internal/controller/prefectdeployment_controller.go
+++ b/internal/controller/prefectdeployment_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -190,6 +191,9 @@ func (r *PrefectDeploymentReconciler) syncWithPrefect(ctx context.Context, deplo
 	var prefectDeployment *prefect.Deployment
 	if deployment.Status.Id != nil && *deployment.Status.Id != "" {
 		prefectDeployment, err = prefectClient.UpdateDeployment(ctx, *deployment.Status.Id, deploymentSpec)
+		if errors.Is(err, prefect.ErrDeploymentNotFound) {
+			prefectDeployment, err = prefectClient.CreateOrUpdateDeployment(ctx, deploymentSpec)
+		}
 	} else {
 		prefectDeployment, err = prefectClient.CreateOrUpdateDeployment(ctx, deploymentSpec)
 	}
@@ -233,46 +237,75 @@ func (r *PrefectDeploymentReconciler) reconcileSchedules(ctx context.Context, cl
 		return fmt.Errorf("get current schedules: %w", err)
 	}
 
-	existingBySlug := make(map[string]prefect.DeploymentSchedule, len(current.Schedules))
-	for _, e := range current.Schedules {
-		if e.Slug != nil {
-			existingBySlug[*e.Slug] = e
-		}
-	}
-
+	desiredBySlug := make(map[string]prefect.DeploymentSchedule, len(desired))
 	var toCreate []prefect.DeploymentSchedule
 	for _, d := range desired {
 		if d.Slug == nil {
 			toCreate = append(toCreate, d)
 			continue
 		}
-		e, ok := existingBySlug[*d.Slug]
-		if !ok {
-			toCreate = append(toCreate, d)
+		desiredBySlug[*d.Slug] = d
+	}
+
+	for _, e := range current.Schedules {
+		d, ok := desiredBySlug[slugValue(e.Slug)]
+		if e.Slug == nil || !ok {
+			if err := client.DeleteDeploymentSchedule(ctx, deploymentID, e.ID); err != nil {
+				return fmt.Errorf("delete schedule: %w", err)
+			}
 			continue
 		}
-		delete(existingBySlug, *d.Slug)
-		if err := client.UpdateDeploymentSchedule(ctx, deploymentID, e.ID, prefect.DeploymentScheduleUpdate{
-			Schedule:         &d.Schedule,
-			Active:           d.Active,
-			MaxScheduledRuns: d.MaxScheduledRuns,
-		}); err != nil {
-			return fmt.Errorf("update schedule: %w", err)
+		delete(desiredBySlug, *e.Slug)
+		if scheduleNeedsUpdate(e, d) {
+			if err := client.UpdateDeploymentSchedule(ctx, deploymentID, e.ID, prefect.DeploymentScheduleUpdate{
+				Schedule:         &d.Schedule,
+				Active:           d.Active,
+				MaxScheduledRuns: d.MaxScheduledRuns,
+			}); err != nil {
+				return fmt.Errorf("update schedule: %w", err)
+			}
 		}
 	}
 
+	for _, d := range desiredBySlug {
+		toCreate = append(toCreate, d)
+	}
 	if len(toCreate) > 0 {
 		if err := client.CreateDeploymentSchedules(ctx, deploymentID, toCreate); err != nil {
 			return fmt.Errorf("create schedules: %w", err)
 		}
 	}
-
-	for _, e := range existingBySlug {
-		if err := client.DeleteDeploymentSchedule(ctx, deploymentID, e.ID); err != nil {
-			return fmt.Errorf("delete schedule: %w", err)
-		}
-	}
 	return nil
+}
+
+func slugValue(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func scheduleNeedsUpdate(current, desired prefect.DeploymentSchedule) bool {
+	c, d := current.Schedule, desired.Schedule
+	if d.Cron != nil && (c.Cron == nil || *c.Cron != *d.Cron) {
+		return true
+	}
+	if d.RRule != nil && (c.RRule == nil || *c.RRule != *d.RRule) {
+		return true
+	}
+	if d.Interval != nil && (c.Interval == nil || *c.Interval != *d.Interval) {
+		return true
+	}
+	if d.Timezone != nil && (c.Timezone == nil || *c.Timezone != *d.Timezone) {
+		return true
+	}
+	if d.DayOr != nil && (c.DayOr == nil || *c.DayOr != *d.DayOr) {
+		return true
+	}
+	if desired.Active != nil && (current.Active == nil || *current.Active != *desired.Active) {
+		return true
+	}
+	return false
 }
 
 // setCondition sets a condition on the deployment status

--- a/internal/controller/prefectdeployment_controller.go
+++ b/internal/controller/prefectdeployment_controller.go
@@ -184,10 +184,24 @@ func (r *PrefectDeploymentReconciler) syncWithPrefect(ctx context.Context, deplo
 		return ctrl.Result{}, err
 	}
 
-	prefectDeployment, err := prefectClient.CreateOrUpdateDeployment(ctx, deploymentSpec)
+	desiredSchedules := deploymentSpec.Schedules
+	deploymentSpec.Schedules = nil
+
+	var prefectDeployment *prefect.Deployment
+	if deployment.Status.Id != nil && *deployment.Status.Id != "" {
+		prefectDeployment, err = prefectClient.UpdateDeployment(ctx, *deployment.Status.Id, deploymentSpec)
+	} else {
+		prefectDeployment, err = prefectClient.CreateOrUpdateDeployment(ctx, deploymentSpec)
+	}
 	if err != nil {
 		log.Error(err, "Failed to create or update deployment in Prefect", "deployment", deployment.Name)
 		r.setCondition(deployment, PrefectDeploymentConditionSynced, metav1.ConditionFalse, "SyncError", err.Error())
+		return ctrl.Result{}, err
+	}
+
+	if err := r.reconcileSchedules(ctx, prefectClient, prefectDeployment.ID, desiredSchedules); err != nil {
+		log.Error(err, "Failed to reconcile deployment schedules", "deployment", deployment.Name)
+		r.setCondition(deployment, PrefectDeploymentConditionSynced, metav1.ConditionFalse, "ScheduleSyncError", err.Error())
 		return ctrl.Result{}, err
 	}
 
@@ -211,6 +225,54 @@ func (r *PrefectDeploymentReconciler) syncWithPrefect(ctx context.Context, deplo
 
 	log.Info("Successfully synced deployment with Prefect", "deploymentId", prefectDeployment.ID)
 	return ctrl.Result{RequeueAfter: RequeueIntervalReady}, nil
+}
+
+func (r *PrefectDeploymentReconciler) reconcileSchedules(ctx context.Context, client prefect.PrefectClient, deploymentID string, desired []prefect.DeploymentSchedule) error {
+	current, err := client.GetDeployment(ctx, deploymentID)
+	if err != nil {
+		return fmt.Errorf("get current schedules: %w", err)
+	}
+
+	existingBySlug := make(map[string]prefect.DeploymentSchedule, len(current.Schedules))
+	for _, e := range current.Schedules {
+		if e.Slug != nil {
+			existingBySlug[*e.Slug] = e
+		}
+	}
+
+	var toCreate []prefect.DeploymentSchedule
+	for _, d := range desired {
+		if d.Slug == nil {
+			toCreate = append(toCreate, d)
+			continue
+		}
+		e, ok := existingBySlug[*d.Slug]
+		if !ok {
+			toCreate = append(toCreate, d)
+			continue
+		}
+		delete(existingBySlug, *d.Slug)
+		if err := client.UpdateDeploymentSchedule(ctx, deploymentID, e.ID, prefect.DeploymentScheduleUpdate{
+			Schedule:         &d.Schedule,
+			Active:           d.Active,
+			MaxScheduledRuns: d.MaxScheduledRuns,
+		}); err != nil {
+			return fmt.Errorf("update schedule: %w", err)
+		}
+	}
+
+	if len(toCreate) > 0 {
+		if err := client.CreateDeploymentSchedules(ctx, deploymentID, toCreate); err != nil {
+			return fmt.Errorf("create schedules: %w", err)
+		}
+	}
+
+	for _, e := range existingBySlug {
+		if err := client.DeleteDeploymentSchedule(ctx, deploymentID, e.ID); err != nil {
+			return fmt.Errorf("delete schedule: %w", err)
+		}
+	}
+	return nil
 }
 
 // setCondition sets a condition on the deployment status

--- a/internal/controller/schedule_reconcile_test.go
+++ b/internal/controller/schedule_reconcile_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/PrefectHQ/prefect-operator/internal/prefect"
+)
+
+func TestReconcileSchedules(t *testing.T) {
+	ctx := context.Background()
+	r := &PrefectDeploymentReconciler{}
+	mock := prefect.NewMockClient()
+
+	dep, err := mock.CreateOrUpdateDeployment(ctx, &prefect.DeploymentSpec{Name: "d", FlowID: "f"})
+	if err != nil {
+		t.Fatalf("seed deployment: %v", err)
+	}
+	depID := dep.ID
+
+	cron := "* * * * *"
+	slug := "default"
+	active := true
+	desired := []prefect.DeploymentSchedule{{
+		Slug:     &slug,
+		Active:   &active,
+		Schedule: prefect.Schedule{Cron: &cron},
+	}}
+
+	if err := r.reconcileSchedules(ctx, mock, depID, desired); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, _ := mock.GetDeployment(ctx, depID)
+	if len(got.Schedules) != 1 {
+		t.Fatalf("want 1 schedule after create, got %d", len(got.Schedules))
+	}
+	schedID := got.Schedules[0].ID
+
+	if err := r.reconcileSchedules(ctx, mock, depID, desired); err != nil {
+		t.Fatalf("noop: %v", err)
+	}
+	got2, _ := mock.GetDeployment(ctx, depID)
+	if len(got2.Schedules) != 1 || got2.Schedules[0].ID != schedID {
+		t.Fatalf("schedule ID churned on unchanged reconcile: %+v", got2.Schedules)
+	}
+
+	newCron := "*/5 * * * *"
+	desired[0].Schedule.Cron = &newCron
+	if err := r.reconcileSchedules(ctx, mock, depID, desired); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got3, _ := mock.GetDeployment(ctx, depID)
+	if len(got3.Schedules) != 1 || got3.Schedules[0].ID != schedID {
+		t.Fatalf("update should keep the same schedule ID: %+v", got3.Schedules)
+	}
+	if got3.Schedules[0].Schedule.Cron == nil || *got3.Schedules[0].Schedule.Cron != newCron {
+		t.Fatalf("cron not updated in place: %+v", got3.Schedules[0].Schedule)
+	}
+
+	if err := r.reconcileSchedules(ctx, mock, depID, nil); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	got4, _ := mock.GetDeployment(ctx, depID)
+	if len(got4.Schedules) != 0 {
+		t.Fatalf("want 0 schedules after delete, got %d", len(got4.Schedules))
+	}
+}

--- a/internal/controller/schedule_reconcile_test.go
+++ b/internal/controller/schedule_reconcile_test.go
@@ -3,72 +3,102 @@ Copyright 2024.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package controller
 
 import (
 	"context"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/PrefectHQ/prefect-operator/internal/prefect"
 )
 
-func TestReconcileSchedules(t *testing.T) {
-	ctx := context.Background()
-	r := &PrefectDeploymentReconciler{}
-	mock := prefect.NewMockClient()
+var _ = Describe("PrefectDeployment schedule reconciliation", func() {
+	var (
+		ctx   context.Context
+		r     *PrefectDeploymentReconciler
+		mock  *prefect.MockClient
+		depID string
+	)
 
-	dep, err := mock.CreateOrUpdateDeployment(ctx, &prefect.DeploymentSpec{Name: "d", FlowID: "f"})
-	if err != nil {
-		t.Fatalf("seed deployment: %v", err)
-	}
-	depID := dep.ID
+	newString := func(s string) *string { return &s }
+	newBool := func(b bool) *bool { return &b }
 
-	cron := "* * * * *"
-	slug := "default"
-	active := true
-	desired := []prefect.DeploymentSchedule{{
-		Slug:     &slug,
-		Active:   &active,
-		Schedule: prefect.Schedule{Cron: &cron},
-	}}
+	BeforeEach(func() {
+		ctx = context.Background()
+		r = &PrefectDeploymentReconciler{}
+		mock = prefect.NewMockClient()
+		dep, err := mock.CreateOrUpdateDeployment(ctx, &prefect.DeploymentSpec{Name: "d", FlowID: "f"})
+		Expect(err).NotTo(HaveOccurred())
+		depID = dep.ID
+	})
 
-	if err := r.reconcileSchedules(ctx, mock, depID, desired); err != nil {
-		t.Fatalf("create: %v", err)
-	}
-	got, _ := mock.GetDeployment(ctx, depID)
-	if len(got.Schedules) != 1 {
-		t.Fatalf("want 1 schedule after create, got %d", len(got.Schedules))
-	}
-	schedID := got.Schedules[0].ID
+	It("creates, updates in place, and deletes by slug while keeping the schedule ID stable", func() {
+		desired := []prefect.DeploymentSchedule{{
+			Slug:     newString("default"),
+			Active:   newBool(true),
+			Schedule: prefect.Schedule{Cron: newString("* * * * *")},
+		}}
 
-	if err := r.reconcileSchedules(ctx, mock, depID, desired); err != nil {
-		t.Fatalf("noop: %v", err)
-	}
-	got2, _ := mock.GetDeployment(ctx, depID)
-	if len(got2.Schedules) != 1 || got2.Schedules[0].ID != schedID {
-		t.Fatalf("schedule ID churned on unchanged reconcile: %+v", got2.Schedules)
-	}
+		By("creating when absent")
+		Expect(r.reconcileSchedules(ctx, mock, depID, desired)).To(Succeed())
+		got, err := mock.GetDeployment(ctx, depID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.Schedules).To(HaveLen(1))
+		schedID := got.Schedules[0].ID
 
-	newCron := "*/5 * * * *"
-	desired[0].Schedule.Cron = &newCron
-	if err := r.reconcileSchedules(ctx, mock, depID, desired); err != nil {
-		t.Fatalf("update: %v", err)
-	}
-	got3, _ := mock.GetDeployment(ctx, depID)
-	if len(got3.Schedules) != 1 || got3.Schedules[0].ID != schedID {
-		t.Fatalf("update should keep the same schedule ID: %+v", got3.Schedules)
-	}
-	if got3.Schedules[0].Schedule.Cron == nil || *got3.Schedules[0].Schedule.Cron != newCron {
-		t.Fatalf("cron not updated in place: %+v", got3.Schedules[0].Schedule)
-	}
+		By("leaving the ID unchanged on an unchanged reconcile")
+		Expect(r.reconcileSchedules(ctx, mock, depID, desired)).To(Succeed())
+		got, err = mock.GetDeployment(ctx, depID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.Schedules).To(HaveLen(1))
+		Expect(got.Schedules[0].ID).To(Equal(schedID))
 
-	if err := r.reconcileSchedules(ctx, mock, depID, nil); err != nil {
-		t.Fatalf("delete: %v", err)
-	}
-	got4, _ := mock.GetDeployment(ctx, depID)
-	if len(got4.Schedules) != 0 {
-		t.Fatalf("want 0 schedules after delete, got %d", len(got4.Schedules))
-	}
-}
+		By("updating in place when the cron changes")
+		desired[0].Schedule.Cron = newString("*/5 * * * *")
+		Expect(r.reconcileSchedules(ctx, mock, depID, desired)).To(Succeed())
+		got, err = mock.GetDeployment(ctx, depID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.Schedules).To(HaveLen(1))
+		Expect(got.Schedules[0].ID).To(Equal(schedID))
+		Expect(*got.Schedules[0].Schedule.Cron).To(Equal("*/5 * * * *"))
+
+		By("deleting when no longer desired")
+		Expect(r.reconcileSchedules(ctx, mock, depID, nil)).To(Succeed())
+		got, err = mock.GetDeployment(ctx, depID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.Schedules).To(BeEmpty())
+	})
+
+	It("prunes a schedule with no slug that isn't part of the desired set", func() {
+		By("seeding a slugless schedule directly on the deployment")
+		Expect(mock.CreateDeploymentSchedules(ctx, depID, []prefect.DeploymentSchedule{{
+			Schedule: prefect.Schedule{Cron: newString("0 * * * *")},
+		}})).To(Succeed())
+
+		By("reconciling to a single slugged schedule")
+		desired := []prefect.DeploymentSchedule{{
+			Slug:     newString("default"),
+			Active:   newBool(true),
+			Schedule: prefect.Schedule{Cron: newString("* * * * *")},
+		}}
+		Expect(r.reconcileSchedules(ctx, mock, depID, desired)).To(Succeed())
+
+		got, err := mock.GetDeployment(ctx, depID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.Schedules).To(HaveLen(1))
+		Expect(got.Schedules[0].Slug).To(Equal(newString("default")))
+	})
+})

--- a/internal/prefect/client.go
+++ b/internal/prefect/client.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -32,6 +33,10 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// ErrDeploymentNotFound is returned when a deployment no longer exists in Prefect
+// (e.g. deleted in the UI), so callers can fall back to recreating it.
+var ErrDeploymentNotFound = errors.New("deployment not found")
 
 // isSuccessStatusCode returns true if the HTTP status code indicates success (2xx range)
 func isSuccessStatusCode(statusCode int) bool {
@@ -445,12 +450,15 @@ func (c *Client) UpdateDeployment(ctx context.Context, id string, deployment *De
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrDeploymentNotFound
+	}
 	if !isSuccessStatusCode(resp.StatusCode) {
 		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
 	if resp.StatusCode == http.StatusNoContent || len(bytes.TrimSpace(body)) == 0 {
-		return &Deployment{ID: id, FlowID: deployment.FlowID}, nil
+		return c.GetDeployment(ctx, id)
 	}
 
 	var result Deployment

--- a/internal/prefect/client.go
+++ b/internal/prefect/client.go
@@ -50,6 +50,9 @@ type PrefectClient interface {
 	UpdateDeployment(ctx context.Context, id string, deployment *DeploymentSpec) (*Deployment, error)
 	// DeleteDeployment deletes a deployment
 	DeleteDeployment(ctx context.Context, id string) error
+	CreateDeploymentSchedules(ctx context.Context, deploymentID string, schedules []DeploymentSchedule) error
+	UpdateDeploymentSchedule(ctx context.Context, deploymentID, scheduleID string, update DeploymentScheduleUpdate) error
+	DeleteDeploymentSchedule(ctx context.Context, deploymentID, scheduleID string) error
 	// CreateOrGetFlow creates a new flow or returns an existing one with the same name
 	CreateOrGetFlow(ctx context.Context, flow *FlowSpec) (*Flow, error)
 	// GetFlowByName retrieves a flow by name
@@ -243,7 +246,7 @@ type Schedule struct {
 // DeploymentSchedule represents a deployment schedule in the Prefect API.
 // This matches the DeploymentScheduleCreate schema which wraps the schedule object.
 type DeploymentSchedule struct {
-	// Slug is a unique identifier for the schedule
+	ID   string  `json:"id,omitempty"`
 	Slug *string `json:"slug,omitempty"`
 
 	// Schedule contains the actual schedule configuration (interval, cron, or rrule)
@@ -402,9 +405,19 @@ func (c *Client) UpdateDeployment(ctx context.Context, id string, deployment *De
 	url := fmt.Sprintf("%s/deployments/%s", c.BaseURL, id)
 	c.log.V(1).Info("Updating deployment", "url", url, "deploymentId", id)
 
-	jsonData, err := json.Marshal(deployment)
+	raw, err := json.Marshal(deployment)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal deployment updates: %w", err)
+	}
+	var updateBody map[string]any
+	if err := json.Unmarshal(raw, &updateBody); err != nil {
+		return nil, fmt.Errorf("failed to prepare deployment update body: %w", err)
+	}
+	delete(updateBody, "name")
+	delete(updateBody, "flow_id")
+	jsonData, err := json.Marshal(updateBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal deployment update body: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "PATCH", url, bytes.NewBuffer(jsonData))
@@ -434,6 +447,10 @@ func (c *Client) UpdateDeployment(ctx context.Context, id string, deployment *De
 
 	if !isSuccessStatusCode(resp.StatusCode) {
 		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	if resp.StatusCode == http.StatusNoContent || len(bytes.TrimSpace(body)) == 0 {
+		return &Deployment{ID: id, FlowID: deployment.FlowID}, nil
 	}
 
 	var result Deployment
@@ -476,6 +493,65 @@ func (c *Client) DeleteDeployment(ctx context.Context, id string) error {
 
 	c.log.V(1).Info("Deployment deleted successfully", "deploymentId", id)
 	return nil
+}
+
+type DeploymentScheduleUpdate struct {
+	Schedule         *Schedule `json:"schedule,omitempty"`
+	Active           *bool     `json:"active,omitempty"`
+	MaxScheduledRuns *int      `json:"max_scheduled_runs,omitempty"`
+}
+
+func (c *Client) scheduleSubResource(ctx context.Context, method, url string, jsonData []byte) error {
+	var bodyReader io.Reader
+	if jsonData != nil {
+		bodyReader = bytes.NewBuffer(jsonData)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	if jsonData != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.APIKey != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.APIKey))
+	}
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to make request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+	if !isSuccessStatusCode(resp.StatusCode) {
+		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+func (c *Client) CreateDeploymentSchedules(ctx context.Context, deploymentID string, schedules []DeploymentSchedule) error {
+	url := fmt.Sprintf("%s/deployments/%s/schedules", c.BaseURL, deploymentID)
+	jsonData, err := json.Marshal(schedules)
+	if err != nil {
+		return fmt.Errorf("failed to marshal schedules: %w", err)
+	}
+	return c.scheduleSubResource(ctx, "POST", url, jsonData)
+}
+
+func (c *Client) UpdateDeploymentSchedule(ctx context.Context, deploymentID, scheduleID string, update DeploymentScheduleUpdate) error {
+	url := fmt.Sprintf("%s/deployments/%s/schedules/%s", c.BaseURL, deploymentID, scheduleID)
+	jsonData, err := json.Marshal(update)
+	if err != nil {
+		return fmt.Errorf("failed to marshal schedule update: %w", err)
+	}
+	return c.scheduleSubResource(ctx, "PATCH", url, jsonData)
+}
+
+func (c *Client) DeleteDeploymentSchedule(ctx context.Context, deploymentID, scheduleID string) error {
+	url := fmt.Sprintf("%s/deployments/%s/schedules/%s", c.BaseURL, deploymentID, scheduleID)
+	return c.scheduleSubResource(ctx, "DELETE", url, nil)
 }
 
 // CreateOrGetFlow creates a new flow or returns an existing one with the same name

--- a/internal/prefect/client_test.go
+++ b/internal/prefect/client_test.go
@@ -559,10 +559,10 @@ var _ = Describe("Prefect HTTP Client", func() {
 				Expect(r.URL.Path).To(Equal("/deployments/deployment-12345"))
 				Expect(r.Header.Get("Content-Type")).To(Equal("application/json"))
 
-				// Verify request body contains updated deployment spec
 				var deploymentSpec DeploymentSpec
 				_ = json.NewDecoder(r.Body).Decode(&deploymentSpec)
-				Expect(deploymentSpec.Name).To(Equal("updated-deployment"))
+				Expect(deploymentSpec.Name).To(BeEmpty())
+				Expect(deploymentSpec.FlowID).To(BeEmpty())
 				Expect(*deploymentSpec.Paused).To(BeTrue())
 
 				w.Header().Set("Content-Type", "application/json")

--- a/internal/prefect/mock.go
+++ b/internal/prefect/mock.go
@@ -326,6 +326,76 @@ func (m *MockClient) DeleteDeployment(ctx context.Context, deploymentID string) 
 	return nil
 }
 
+func (m *MockClient) CreateDeploymentSchedules(ctx context.Context, deploymentID string, schedules []DeploymentSchedule) error {
+	if m.ShouldFailUpdate {
+		return fmt.Errorf("mock error: %s", m.FailureMessage)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	d, ok := m.deployments[deploymentID]
+	if !ok {
+		return fmt.Errorf("mock error: deployment %s not found", deploymentID)
+	}
+	for _, s := range schedules {
+		if s.ID == "" {
+			if s.Slug != nil {
+				s.ID = "sched-" + *s.Slug
+			} else {
+				s.ID = fmt.Sprintf("sched-%d", len(d.Schedules))
+			}
+		}
+		d.Schedules = append(d.Schedules, s)
+	}
+	return nil
+}
+
+func (m *MockClient) UpdateDeploymentSchedule(ctx context.Context, deploymentID, scheduleID string, update DeploymentScheduleUpdate) error {
+	if m.ShouldFailUpdate {
+		return fmt.Errorf("mock error: %s", m.FailureMessage)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	d, ok := m.deployments[deploymentID]
+	if !ok {
+		return fmt.Errorf("mock error: deployment %s not found", deploymentID)
+	}
+	for i := range d.Schedules {
+		if d.Schedules[i].ID == scheduleID {
+			if update.Schedule != nil {
+				d.Schedules[i].Schedule = *update.Schedule
+			}
+			if update.Active != nil {
+				d.Schedules[i].Active = update.Active
+			}
+			if update.MaxScheduledRuns != nil {
+				d.Schedules[i].MaxScheduledRuns = update.MaxScheduledRuns
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("mock error: schedule %s not found", scheduleID)
+}
+
+func (m *MockClient) DeleteDeploymentSchedule(ctx context.Context, deploymentID, scheduleID string) error {
+	if m.ShouldFailDelete {
+		return fmt.Errorf("mock error: %s", m.FailureMessage)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	d, ok := m.deployments[deploymentID]
+	if !ok {
+		return fmt.Errorf("mock error: deployment %s not found", deploymentID)
+	}
+	kept := make([]DeploymentSchedule, 0, len(d.Schedules))
+	for _, s := range d.Schedules {
+		if s.ID != scheduleID {
+			kept = append(kept, s)
+		}
+	}
+	d.Schedules = kept
+	return nil
+}
+
 // Helper methods for testing
 
 // GetAllDeployments returns all deployments in the mock store (for testing)

--- a/internal/prefect/mock.go
+++ b/internal/prefect/mock.go
@@ -337,6 +337,13 @@ func (m *MockClient) CreateDeploymentSchedules(ctx context.Context, deploymentID
 		return fmt.Errorf("mock error: deployment %s not found", deploymentID)
 	}
 	for _, s := range schedules {
+		if s.Slug != nil {
+			for _, ex := range d.Schedules {
+				if ex.Slug != nil && *ex.Slug == *s.Slug {
+					return fmt.Errorf("mock error: schedule slug %q already exists (409)", *s.Slug)
+				}
+			}
+		}
 		if s.ID == "" {
 			if s.Slug != nil {
 				s.ID = "sched-" + *s.Slug


### PR DESCRIPTION
## Problem
Cron-scheduled deployments intermittently produced **duplicate flow runs** for the same minute (the 2nd failing the flow's uniqueness guard). The reconciler re-created the deployment's schedule on essentially every reconcile, minting a **new schedule ID**; Prefect's auto-scheduler keys created runs by `schedule_id`, so when the ID changed between two scheduler passes the same cron tick got scheduled twice.

## Root cause (all confirmed against a live Prefect server)
- `POST /deployments/` (the upsert) with a `schedules` field **replaces** the schedule set → new ID each call; with an **absent** `schedules` field it **wipes** the schedules.
- `PATCH /deployments/{id}` (DeploymentUpdate) **forbids** `name`/`flow_id` (`extra_forbidden` → 422), and returns **204 No Content**.
- A single schedule can be edited only via `PATCH /deployments/{id}/schedules/{id}`, which updates **in place** (preserves the ID, applies the change) — the same call the Prefect UI makes on save.

## Fix
1. Update an existing deployment with `PATCH /deployments/{id}` (POST only for first creation), **without** `schedules` in the body, `name`/`flow_id` stripped, treating a 204/empty response as success.
2. Reconcile schedules separately via the `.../schedules` sub-resource matched by slug: `PATCH` in place / `POST` new / `DELETE` removed. Existing schedules are read via `GetDeployment`.

New client methods + interface + mock; `DeploymentSchedule` gains an `ID` field; adds a `reconcileSchedules` unit test. `go build`/`vet`/`test` pass.

## Validated
Verified end-to-end on a live dev cluster (Prefect 3.6.28): with this change the schedule **ID stays stable across reconciles** (no more duplicate/failed runs) while schedule **edits self-heal in place**. Confirmed both directly against the Prefect API and by running the built controller image; deletion is handled by the existing deployment-level cascade (unchanged).


## Semantics note (PATCH vs the old POST upsert)
Updates now go through `PATCH /deployments/{id}`, which the server applies with `exclude_unset`. So **removing an optional field from the CRD spec no longer clears it** in Prefect (e.g. dropping `paused: true` leaves the deployment paused), whereas the old `POST` upsert reset unset fields to defaults. This is intentional — set fields explicitly to change them; the reconciler no longer clobbers server state for fields the CR doesn't declare.
