### PR TITLE
feat: make deployment flow_name immutable

### DIFF
--- a/api/v1/prefectdeployment_types.go
+++ b/api/v1/prefectdeployment_types.go
@@ -51,6 +51,7 @@ type PrefectWorkPoolReference struct {
 }
 
 // PrefectDeploymentConfiguration defines the deployment specification
+// +kubebuilder:validation:XValidation:rule="!has(self.flow_name) || !has(oldSelf.flow_name) || self.flow_name == oldSelf.flow_name",message="flow_name is immutable; delete and recreate the deployment to change the flow"
 type PrefectDeploymentConfiguration struct {
 	// Description is a human-readable description of the deployment
 	// +optional

--- a/deploy/charts/prefect-operator/crds/prefect.io_prefectdeployments.yaml
+++ b/deploy/charts/prefect-operator/crds/prefect.io_prefectdeployments.yaml
@@ -211,6 +211,11 @@ spec:
                 required:
                 - entrypoint
                 type: object
+                x-kubernetes-validations:
+                - message: flow_name is immutable; delete and recreate the deployment
+                    to change the flow
+                  rule: '!has(self.flow_name) || !has(oldSelf.flow_name) || self.flow_name
+                    == oldSelf.flow_name'
               server:
                 description: Server configuration for connecting to Prefect API
                 properties:


### PR DESCRIPTION
## What
Marks `spec.deployment.flow_name` **immutable** on the `PrefectDeployment` CRD via a CEL transition rule (`self.flow_name == oldSelf.flow_name`).

## Why
A deployment's flow (`flow_id`) is immutable in Prefect — `PATCH /deployments/{id}` forbids `flow_id`. So editing `flow_name` in an existing CR is a **silent no-op**: the operator resolves a new `flow_id`, it's dropped from the PATCH, and the deployment keeps running the original flow. Rejecting the change at admission turns that into a clear error ("delete and recreate the deployment to change the flow").

## Scope (verified against a live Prefect server)
Only `flow_name` is pinned. The other editable fields update in place and are deliberately left mutable:
- **`entrypoint`** — mutable (PATCH `204`, change applied); **not** pinned.
- **`workPool`** — mutable (as in the UI); not pinned.
- **`name`** — already immutable (it's `metadata.name`).

CRD regenerated (controller-gen). `go build`/`test ./api/...` pass. Independent of the schedule fix (#3).
