### PR TITLE
fix: compare maxScheduledRuns and anchorDate when diffing schedules

### DIFF
--- a/internal/controller/prefectdeployment_controller.go
+++ b/internal/controller/prefectdeployment_controller.go
@@ -296,6 +296,9 @@ func scheduleNeedsUpdate(current, desired prefect.DeploymentSchedule) bool {
 	if d.Interval != nil && (c.Interval == nil || *c.Interval != *d.Interval) {
 		return true
 	}
+	if d.AnchorDate != nil && (c.AnchorDate == nil || !c.AnchorDate.Equal(*d.AnchorDate)) {
+		return true
+	}
 	if d.Timezone != nil && (c.Timezone == nil || *c.Timezone != *d.Timezone) {
 		return true
 	}
@@ -303,6 +306,9 @@ func scheduleNeedsUpdate(current, desired prefect.DeploymentSchedule) bool {
 		return true
 	}
 	if desired.Active != nil && (current.Active == nil || *current.Active != *desired.Active) {
+		return true
+	}
+	if desired.MaxScheduledRuns != nil && (current.MaxScheduledRuns == nil || *current.MaxScheduledRuns != *desired.MaxScheduledRuns) {
 		return true
 	}
 	return false

--- a/internal/controller/schedule_reconcile_test.go
+++ b/internal/controller/schedule_reconcile_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,6 +36,9 @@ var _ = Describe("PrefectDeployment schedule reconciliation", func() {
 
 	newString := func(s string) *string { return &s }
 	newBool := func(b bool) *bool { return &b }
+	newInt := func(i int) *int { return &i }
+	newFloat := func(f float64) *float64 { return &f }
+	newTime := func(t time.Time) *time.Time { return &t }
 
 	BeforeEach(func() {
 		ctx = context.Background()
@@ -80,6 +84,93 @@ var _ = Describe("PrefectDeployment schedule reconciliation", func() {
 		got, err = mock.GetDeployment(ctx, depID)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(got.Schedules).To(BeEmpty())
+	})
+
+	It("makes no update calls when schedules are unchanged", func() {
+		desired := []prefect.DeploymentSchedule{{
+			Slug:             newString("default"),
+			Active:           newBool(true),
+			MaxScheduledRuns: newInt(3),
+			Schedule:         prefect.Schedule{Cron: newString("* * * * *")},
+		}}
+
+		Expect(r.reconcileSchedules(ctx, mock, depID, desired)).To(Succeed())
+		Expect(r.reconcileSchedules(ctx, mock, depID, desired)).To(Succeed())
+		Expect(mock.UpdateScheduleCalls).To(BeZero())
+	})
+
+	It("applies a maxScheduledRuns-only change in place", func() {
+		desired := []prefect.DeploymentSchedule{{
+			Slug:             newString("default"),
+			Active:           newBool(true),
+			MaxScheduledRuns: newInt(3),
+			Schedule:         prefect.Schedule{Cron: newString("* * * * *")},
+		}}
+		Expect(r.reconcileSchedules(ctx, mock, depID, desired)).To(Succeed())
+		got, err := mock.GetDeployment(ctx, depID)
+		Expect(err).NotTo(HaveOccurred())
+		schedID := got.Schedules[0].ID
+
+		desired[0].MaxScheduledRuns = newInt(5)
+		Expect(r.reconcileSchedules(ctx, mock, depID, desired)).To(Succeed())
+
+		got, err = mock.GetDeployment(ctx, depID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.Schedules).To(HaveLen(1))
+		Expect(got.Schedules[0].ID).To(Equal(schedID))
+		Expect(*got.Schedules[0].MaxScheduledRuns).To(Equal(5))
+	})
+
+	It("applies an anchorDate-only change to an interval schedule in place", func() {
+		anchor := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		desired := []prefect.DeploymentSchedule{{
+			Slug:   newString("hourly"),
+			Active: newBool(true),
+			Schedule: prefect.Schedule{
+				Interval:   newFloat(3600),
+				AnchorDate: newTime(anchor),
+			},
+		}}
+		Expect(r.reconcileSchedules(ctx, mock, depID, desired)).To(Succeed())
+		got, err := mock.GetDeployment(ctx, depID)
+		Expect(err).NotTo(HaveOccurred())
+		schedID := got.Schedules[0].ID
+
+		By("not updating when the anchor is the same instant in another zone")
+		desired[0].Schedule.AnchorDate = newTime(anchor.In(time.FixedZone("UTC+5", 5*60*60)))
+		Expect(r.reconcileSchedules(ctx, mock, depID, desired)).To(Succeed())
+		Expect(mock.UpdateScheduleCalls).To(BeZero())
+
+		By("updating in place when the anchor instant changes")
+		newAnchor := anchor.Add(30 * time.Minute)
+		desired[0].Schedule.AnchorDate = newTime(newAnchor)
+		Expect(r.reconcileSchedules(ctx, mock, depID, desired)).To(Succeed())
+
+		got, err = mock.GetDeployment(ctx, depID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got.Schedules).To(HaveLen(1))
+		Expect(got.Schedules[0].ID).To(Equal(schedID))
+		Expect(got.Schedules[0].Schedule.AnchorDate.Equal(newAnchor)).To(BeTrue())
+	})
+
+	It("does not update an interval schedule when the CR sets no anchorDate but the server defaulted one", func() {
+		By("seeding a schedule with a server-defaulted anchor date")
+		Expect(mock.CreateDeploymentSchedules(ctx, depID, []prefect.DeploymentSchedule{{
+			Slug:   newString("hourly"),
+			Active: newBool(true),
+			Schedule: prefect.Schedule{
+				Interval:   newFloat(3600),
+				AnchorDate: newTime(time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)),
+			},
+		}})).To(Succeed())
+
+		desired := []prefect.DeploymentSchedule{{
+			Slug:     newString("hourly"),
+			Active:   newBool(true),
+			Schedule: prefect.Schedule{Interval: newFloat(3600)},
+		}}
+		Expect(r.reconcileSchedules(ctx, mock, depID, desired)).To(Succeed())
+		Expect(mock.UpdateScheduleCalls).To(BeZero())
 	})
 
 	It("prunes a schedule with no slug that isn't part of the desired set", func() {

--- a/internal/prefect/mock.go
+++ b/internal/prefect/mock.go
@@ -41,6 +41,10 @@ type MockClient struct {
 	ShouldFailDelete     bool
 	ShouldFailFlowCreate bool
 	FailureMessage       string
+
+	// UpdateScheduleCalls counts UpdateDeploymentSchedule calls, so tests can
+	// assert that unchanged schedules are not PATCHed
+	UpdateScheduleCalls int
 }
 
 // NewMockClient creates a new mock Prefect client
@@ -362,6 +366,7 @@ func (m *MockClient) UpdateDeploymentSchedule(ctx context.Context, deploymentID,
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.UpdateScheduleCalls++
 	d, ok := m.deployments[deploymentID]
 	if !ok {
 		return fmt.Errorf("mock error: deployment %s not found", deploymentID)


### PR DESCRIPTION
Follow-up to #302, which skips no-op schedule PATCHes because the Prefect server drops future auto-scheduled runs on every schedule update. The comparison missed two fields we send in the update body, so changing only `maxScheduledRuns` (or only `anchorDate` on an interval schedule) never reached Prefect.

Both comparisons stay one-directional (only fields the CR sets trigger an update) — that turns out to be required for `anchorDate`, since the server [defaults it to now()](https://github.com/PrefectHQ/prefect/blob/0e7435055e18952aa8604dab78507b087a18defb/src/prefect/server/schemas/schedules.py#L58-L60) when the CR doesn't set one, and a two-way compare would PATCH on every sync. Anchor dates are compared as instants with `time.Equal` so a different timezone representation from the API round-trip doesn't count as a change.

Also adds an `UpdateScheduleCalls` counter to the mock client, since ID stability alone can't show whether an unchanged reconcile skipped the PATCH.

<details>
<summary>Session context</summary>

This came out of reviewing #302 against both this codebase and the PrefectHQ/prefect server source. The review confirmed the PR's root cause (the scheduler keys auto-scheduled runs by `scheduled {deployment_id} {schedule_id} {date}`) and surfaced several issues that were fixed in-PR; these two comparison gaps were flagged in the final round but the PR merged first, so we did the follow-up ourselves.

Key decisions:
- Tests first: the two behavior specs failed before the fix and pass after; two additional zero-call specs guard the skip logic (unchanged reconcile, and server-defaulted anchor with no CR anchor).
- Kept the one-directional comparison style deliberately — verified against the server that `DeploymentScheduleUpdate` accepts `max_scheduled_runs`, the core response schema returns it, and `anchor_date` is server-defaulted when absent, which makes bidirectional comparison flap.
- Full controller suite (144 specs), client suite, `go vet`, and `golangci-lint` all green.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)