### PR TITLE
ci: speed up multi-platform image builds

### DIFF
--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -34,9 +34,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -76,3 +73,5 @@ jobs:
           push: ${{ inputs.push }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha,scope=${{ inputs.image }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.image }}

--- a/.github/workflows/images-prs.yaml
+++ b/.github/workflows/images-prs.yaml
@@ -24,6 +24,10 @@ name: Build Images on Pull Requests
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   run_unit_tests:
     uses: ./.github/workflows/tests.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-# Build the manager binary
-FROM golang:1.26 AS builder
+# Build the manager binary on the runner's native architecture. Go cross-compiles
+# the binary for each target without running the compiler through QEMU.
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -16,12 +17,8 @@ COPY cmd/main.go cmd/main.go
 COPY api/ api/
 COPY internal/ internal/
 
-# Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+# Build the statically linked binary for the requested image platform.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
The ARM build spent roughly 17 minutes compiling through QEMU. Use Go's native cross-compilation, reuse BuildKit layers, and cancel superseded PR runs while retaining amd64 and arm64 image validation.

```text
Before: native runner -> QEMU -> ARM Go compiler
After:  native runner -> Go cross-compiler -> ARM binary
```

<details>
<summary>Session context</summary>

A recent PR image build spent 1,027 seconds in the arm64 compile step, compared with 112 seconds for amd64. A clean local multi-platform build completed in roughly 35 seconds after this change, and both resulting binary architectures were verified.
</details>
