### PR TITLE
feat: make PostgreSQL wait image configurable

### DIFF
--- a/PrefectServer.md
+++ b/PrefectServer.md
@@ -3455,6 +3455,14 @@ database with the provided connection information
           EnvVarSource represents a source for the value of an EnvVar.<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>waitForDatabaseImage</b></td>
+        <td>string</td>
+        <td>
+          WaitForDatabaseImage defines the image used by init containers to wait for PostgreSQL.
+The image must include pg_isready. Defaults to "postgres:16-alpine".<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 

--- a/api/v1/prefectserver_types.go
+++ b/api/v1/prefectserver_types.go
@@ -131,6 +131,10 @@ func (s *SQLiteConfiguration) ToEnvVars() []corev1.EnvVar {
 }
 
 type PostgresConfiguration struct {
+	// WaitForDatabaseImage defines the image used by init containers to wait for PostgreSQL.
+	// The image must include pg_isready. Defaults to "postgres:16-alpine".
+	WaitForDatabaseImage string `json:"waitForDatabaseImage,omitempty"`
+
 	Host         *string              `json:"host,omitempty"`
 	HostFrom     *corev1.EnvVarSource `json:"hostFrom,omitempty"`
 	Port         *int                 `json:"port,omitempty"`

--- a/deploy/charts/prefect-operator/crds/prefect.io_prefectservers.yaml
+++ b/deploy/charts/prefect-operator/crds/prefect.io_prefectservers.yaml
@@ -2350,6 +2350,11 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                     type: object
+                  waitForDatabaseImage:
+                    description: |-
+                      WaitForDatabaseImage defines the image used by init containers to wait for PostgreSQL.
+                      The image must include pg_isready. Defaults to "postgres:16-alpine".
+                    type: string
                 type: object
               redis:
                 description: Redis defines whether the server will be deployed with

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -10,8 +10,9 @@ const (
 	MigrationJob = "MigrationJob"
 
 	// Pod data.
-	PrefectDataVolumeName  = "prefect-data"
-	PrefectHomeMountPath   = "/var/lib/prefect/"
-	TerminationMessagePath = "/dev/termination-log"
-	APIPortName            = "api"
+	PrefectDataVolumeName    = "prefect-data"
+	PrefectHomeMountPath     = "/var/lib/prefect/"
+	TerminationMessagePath   = "/dev/termination-log"
+	APIPortName              = "api"
+	DefaultPostgresWaitImage = "postgres:16-alpine"
 )

--- a/internal/controller/prefectserver_controller.go
+++ b/internal/controller/prefectserver_controller.go
@@ -610,9 +610,14 @@ func (r *PrefectServerReconciler) prefectServerService(server *prefectiov1.Prefe
 }
 
 func (r *PrefectServerReconciler) initContainerWaitForPostgres(server *prefectiov1.PrefectServer) corev1.Container {
+	image := server.Spec.Postgres.WaitForDatabaseImage
+	if image == "" {
+		image = constants.DefaultPostgresWaitImage
+	}
+
 	return corev1.Container{
 		Name:            "wait-for-database",
-		Image:           "postgres:16-alpine",
+		Image:           image,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command: []string{
 			"/bin/sh",

--- a/internal/controller/prefectserver_controller_test.go
+++ b/internal/controller/prefectserver_controller_test.go
@@ -48,6 +48,44 @@ var _ = Describe("PrefectServer controller", func() {
 		prefectserver *prefectiov1.PrefectServer
 	)
 
+	Describe("the PostgreSQL database wait image", func() {
+		var (
+			controllerReconciler *PrefectServerReconciler
+			server               *prefectiov1.PrefectServer
+		)
+
+		BeforeEach(func() {
+			controllerReconciler = &PrefectServerReconciler{}
+			server = &prefectiov1.PrefectServer{
+				Spec: prefectiov1.PrefectServerSpec{
+					Postgres: &prefectiov1.PostgresConfiguration{},
+				},
+			}
+		})
+
+		It("uses the default image", func() {
+			deployment := controllerReconciler.postgresDeploymentSpec(server)
+			migrationJob := controllerReconciler.postgresMigrationJob(server)
+
+			Expect(deployment.Template.Spec.InitContainers).To(HaveLen(1))
+			Expect(deployment.Template.Spec.InitContainers[0].Image).To(Equal("postgres:16-alpine"))
+			Expect(migrationJob.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			Expect(migrationJob.Spec.Template.Spec.InitContainers[0].Image).To(Equal("postgres:16-alpine"))
+		})
+
+		It("uses a configured image", func() {
+			server.Spec.Postgres.WaitForDatabaseImage = "registry.example.com/postgres:16-alpine"
+
+			deployment := controllerReconciler.postgresDeploymentSpec(server)
+			migrationJob := controllerReconciler.postgresMigrationJob(server)
+
+			Expect(deployment.Template.Spec.InitContainers).To(HaveLen(1))
+			Expect(deployment.Template.Spec.InitContainers[0].Image).To(Equal("registry.example.com/postgres:16-alpine"))
+			Expect(migrationJob.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			Expect(migrationJob.Spec.Template.Spec.InitContainers[0].Image).To(Equal("registry.example.com/postgres:16-alpine"))
+		})
+	})
+
 	Context("for any server", func() {
 		BeforeEach(func() {
 			ctx = context.Background()


### PR DESCRIPTION
## Summary

PostgreSQL-backed PrefectServer pods use a `pg_isready` init container before starting the server or running migrations. Its image is currently fixed to `postgres:16-alpine`, which prevents clusters with restricted registries from running these pods.

This adds `spec.postgres.waitForDatabaseImage` as an optional override. The setting lives under `postgres` because it only affects the wait containers created for that backend. The existing image remains the default, and configured images must provide `pg_isready`.

```text
spec.postgres.waitForDatabaseImage
              |
              +-- server Deployment init container
              +-- migration Job init container
```

`make test` and `make lint` pass locally.

<details>
<summary>Session context</summary>

A community user reported that their cluster can only pull images from approved internal registries. Reusing the Prefect server image would require replacing the existing `pg_isready` check, so this change keeps the current behavior and makes its image configurable instead.

</details>
