### PR TITLE
fix: skip deployment update when the remote already matches the desired spec

### DIFF
--- a/internal/controller/prefectdeployment_controller.go
+++ b/internal/controller/prefectdeployment_controller.go
@@ -193,9 +193,17 @@ func (r *PrefectDeploymentReconciler) syncWithPrefect(ctx context.Context, deplo
 
 	var prefectDeployment *prefect.Deployment
 	if deployment.Status.Id != nil && *deployment.Status.Id != "" {
-		prefectDeployment, err = prefectClient.UpdateDeployment(ctx, *deployment.Status.Id, deploymentSpec)
-		if errors.Is(err, prefect.ErrDeploymentNotFound) {
-			prefectDeployment, err = prefectClient.CreateOrUpdateDeployment(ctx, deploymentSpec)
+		// Skip the update when nothing changed: every update deletes the
+		// deployment's future auto-scheduled runs.
+		remote, getErr := prefectClient.GetDeployment(ctx, *deployment.Status.Id)
+		if getErr == nil && prefect.DeploymentUpToDate(remote, deploymentSpec) {
+			log.Info("Prefect deployment already up to date, skipping update", "deployment", deployment.Name)
+			prefectDeployment = remote
+		} else {
+			prefectDeployment, err = prefectClient.UpdateDeployment(ctx, *deployment.Status.Id, deploymentSpec)
+			if errors.Is(err, prefect.ErrDeploymentNotFound) {
+				prefectDeployment, err = prefectClient.CreateOrUpdateDeployment(ctx, deploymentSpec)
+			}
 		}
 	} else {
 		prefectDeployment, err = prefectClient.CreateOrUpdateDeployment(ctx, deploymentSpec)

--- a/internal/prefect/client.go
+++ b/internal/prefect/client.go
@@ -197,28 +197,35 @@ type DeploymentSpec struct {
 
 // Deployment represents a Prefect deployment
 type Deployment struct {
-	ID                      string               `json:"id"`
-	Created                 time.Time            `json:"created"`
-	Updated                 time.Time            `json:"updated"`
-	Name                    string               `json:"name"`
-	Version                 *string              `json:"version"`
-	Description             *string              `json:"description"`
-	FlowID                  string               `json:"flow_id"`
-	Paused                  bool                 `json:"paused"`
-	Tags                    []string             `json:"tags"`
-	Parameters              map[string]any       `json:"parameters"`
-	JobVariables            map[string]any       `json:"job_variables"`
-	WorkQueueName           *string              `json:"work_queue_name"`
-	WorkPoolName            *string              `json:"work_pool_name"`
-	Status                  string               `json:"status"`
-	Schedules               []DeploymentSchedule `json:"schedules"`
-	ConcurrencyLimit        *int                 `json:"concurrency_limit"`
-	GlobalConcurrencyLimits []string             `json:"global_concurrency_limits"`
-	Entrypoint              *string              `json:"entrypoint"`
-	Path                    *string              `json:"path"`
-	PullSteps               []map[string]any     `json:"pull_steps"`
-	ParameterOpenAPISchema  map[string]any       `json:"parameter_openapi_schema"`
-	EnforceParameterSchema  bool                 `json:"enforce_parameter_schema"`
+	ID                      string                  `json:"id"`
+	Created                 time.Time               `json:"created"`
+	Updated                 time.Time               `json:"updated"`
+	Name                    string                  `json:"name"`
+	Version                 *string                 `json:"version"`
+	Description             *string                 `json:"description"`
+	FlowID                  string                  `json:"flow_id"`
+	Paused                  bool                    `json:"paused"`
+	Tags                    []string                `json:"tags"`
+	Parameters              map[string]any          `json:"parameters"`
+	JobVariables            map[string]any          `json:"job_variables"`
+	WorkQueueName           *string                 `json:"work_queue_name"`
+	WorkPoolName            *string                 `json:"work_pool_name"`
+	Status                  string                  `json:"status"`
+	Schedules               []DeploymentSchedule    `json:"schedules"`
+	ConcurrencyLimit        *int                    `json:"concurrency_limit"`
+	GlobalConcurrencyLimit  *GlobalConcurrencyLimit `json:"global_concurrency_limit,omitempty"`
+	GlobalConcurrencyLimits []string                `json:"global_concurrency_limits"`
+	Entrypoint              *string                 `json:"entrypoint"`
+	Path                    *string                 `json:"path"`
+	PullSteps               []map[string]any        `json:"pull_steps"`
+	ParameterOpenAPISchema  map[string]any          `json:"parameter_openapi_schema"`
+	EnforceParameterSchema  bool                    `json:"enforce_parameter_schema"`
+}
+
+// GlobalConcurrencyLimit carries the deployment's live concurrency limit;
+// the deprecated top-level concurrency_limit response field is always null.
+type GlobalConcurrencyLimit struct {
+	Limit int `json:"limit"`
 }
 
 // Schedule represents a Prefect deployment schedule.

--- a/internal/prefect/deployment_diff.go
+++ b/internal/prefect/deployment_diff.go
@@ -1,0 +1,96 @@
+package prefect
+
+import "reflect"
+
+// DeploymentUpToDate reports whether the remote deployment already matches
+// every operator-managed field of the desired spec, so the update call (which
+// deletes the deployment's future auto-scheduled runs) can be skipped.
+// Fields the spec omits are not sent in the update and are ignored here.
+func DeploymentUpToDate(remote *Deployment, desired *DeploymentSpec) bool {
+	if remote == nil || desired == nil {
+		return false
+	}
+	if remote.Name != desired.Name || remote.FlowID != desired.FlowID {
+		return false
+	}
+	if !ptrMatches(desired.Description, remote.Description) {
+		return false
+	}
+	if !ptrMatches(desired.Version, remote.Version) {
+		return false
+	}
+	if !ptrMatches(desired.WorkPoolName, remote.WorkPoolName) {
+		return false
+	}
+	if !ptrMatches(desired.WorkQueueName, remote.WorkQueueName) {
+		return false
+	}
+	if !ptrMatches(desired.Entrypoint, remote.Entrypoint) {
+		return false
+	}
+	if !ptrMatches(desired.Path, remote.Path) {
+		return false
+	}
+	if desired.Paused != nil && *desired.Paused != remote.Paused {
+		return false
+	}
+	if desired.EnforceParameterSchema != nil && *desired.EnforceParameterSchema != remote.EnforceParameterSchema {
+		return false
+	}
+	if !concurrencyLimitMatches(remote, desired.ConcurrencyLimit) {
+		return false
+	}
+	if len(desired.Tags) > 0 && !sameStringSet(desired.Tags, remote.Tags) {
+		return false
+	}
+	if desired.Parameters != nil && !reflect.DeepEqual(desired.Parameters, remote.Parameters) {
+		return false
+	}
+	if desired.JobVariables != nil && !reflect.DeepEqual(desired.JobVariables, remote.JobVariables) {
+		return false
+	}
+	if desired.ParameterOpenAPISchema != nil && !reflect.DeepEqual(desired.ParameterOpenAPISchema, remote.ParameterOpenAPISchema) {
+		return false
+	}
+	if desired.PullSteps != nil && !reflect.DeepEqual(desired.PullSteps, remote.PullSteps) {
+		return false
+	}
+	return true
+}
+
+// ptrMatches treats a nil desired value as "not managed" and skips it.
+func ptrMatches[T comparable](desired, remote *T) bool {
+	if desired == nil {
+		return true
+	}
+	return remote != nil && *remote == *desired
+}
+
+// concurrencyLimitMatches reads the remote limit from
+// global_concurrency_limit.limit; the top-level field is deprecated and always null.
+func concurrencyLimitMatches(remote *Deployment, desired *int) bool {
+	if desired == nil {
+		return true
+	}
+	if remote.GlobalConcurrencyLimit != nil {
+		return remote.GlobalConcurrencyLimit.Limit == *desired
+	}
+	return remote.ConcurrencyLimit != nil && *remote.ConcurrencyLimit == *desired
+}
+
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := make(map[string]int, len(a))
+	for _, s := range a {
+		counts[s]++
+	}
+	for _, s := range b {
+		counts[s]--
+		if counts[s] < 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/prefect/deployment_diff_test.go
+++ b/internal/prefect/deployment_diff_test.go
@@ -1,0 +1,110 @@
+package prefect
+
+import "testing"
+
+func strPtr(s string) *string { return &s }
+func intPtr(i int) *int       { return &i }
+func boolPtr(b bool) *bool    { return &b }
+
+func matchingRemoteAndDesired() (*Deployment, *DeploymentSpec) {
+	remote := &Deployment{
+		ID:                     "dep-1",
+		Name:                   "etl",
+		FlowID:                 "flow-1",
+		Paused:                 false,
+		Tags:                   []string{"adsb", "etl"},
+		Parameters:             map[string]any{"lookback": float64(5)},
+		JobVariables:           map[string]any{"env": map[string]any{"FOO": "bar-1"}},
+		WorkPoolName:           strPtr("kubernetes-pipelines-pool"),
+		WorkQueueName:          strPtr("default"),
+		Entrypoint:             strPtr("app/main.py:main"),
+		GlobalConcurrencyLimit: &GlobalConcurrencyLimit{Limit: 3},
+	}
+	desired := &DeploymentSpec{
+		Name:             "etl",
+		FlowID:           "flow-1",
+		Paused:           boolPtr(false),
+		Tags:             []string{"etl", "adsb"}, // order differs on purpose
+		Parameters:       map[string]any{"lookback": float64(5)},
+		JobVariables:     map[string]any{"env": map[string]any{"FOO": "bar-1"}},
+		WorkPoolName:     strPtr("kubernetes-pipelines-pool"),
+		WorkQueueName:    strPtr("default"),
+		Entrypoint:       strPtr("app/main.py:main"),
+		ConcurrencyLimit: intPtr(3),
+	}
+	return remote, desired
+}
+
+func TestDeploymentUpToDate(t *testing.T) {
+	t.Run("matching spec is up to date", func(t *testing.T) {
+		remote, desired := matchingRemoteAndDesired()
+		if !DeploymentUpToDate(remote, desired) {
+			t.Fatal("expected up to date")
+		}
+	})
+
+	t.Run("nil remote is not up to date", func(t *testing.T) {
+		_, desired := matchingRemoteAndDesired()
+		if DeploymentUpToDate(nil, desired) {
+			t.Fatal("expected not up to date")
+		}
+	})
+
+	t.Run("desired-omitted fields are ignored", func(t *testing.T) {
+		remote, desired := matchingRemoteAndDesired()
+		remote.Description = strPtr("remote-only description")
+		remote.Path = strPtr("/remote/path")
+		desired.Paused = nil
+		desired.ConcurrencyLimit = nil
+		desired.Parameters = nil
+		if !DeploymentUpToDate(remote, desired) {
+			t.Fatal("expected up to date when desired omits fields")
+		}
+	})
+
+	t.Run("deprecated top-level concurrency_limit is ignored when global object present", func(t *testing.T) {
+		remote, desired := matchingRemoteAndDesired()
+		remote.ConcurrencyLimit = nil // the API always returns null here
+		if !DeploymentUpToDate(remote, desired) {
+			t.Fatal("expected up to date via global_concurrency_limit")
+		}
+	})
+
+	mutations := map[string]func(remote *Deployment, desired *DeploymentSpec){
+		"name":                     func(_ *Deployment, d *DeploymentSpec) { d.Name = "other" },
+		"flow id":                  func(_ *Deployment, d *DeploymentSpec) { d.FlowID = "flow-2" },
+		"description":              func(_ *Deployment, d *DeploymentSpec) { d.Description = strPtr("new") },
+		"version":                  func(_ *Deployment, d *DeploymentSpec) { d.Version = strPtr("v2") },
+		"work pool":                func(_ *Deployment, d *DeploymentSpec) { d.WorkPoolName = strPtr("other-pool") },
+		"work queue":               func(_ *Deployment, d *DeploymentSpec) { d.WorkQueueName = strPtr("other-queue") },
+		"entrypoint":               func(_ *Deployment, d *DeploymentSpec) { d.Entrypoint = strPtr("app/other.py:main") },
+		"path":                     func(_ *Deployment, d *DeploymentSpec) { d.Path = strPtr("/new/path") },
+		"paused":                   func(_ *Deployment, d *DeploymentSpec) { d.Paused = boolPtr(true) },
+		"enforce parameter schema": func(r *Deployment, d *DeploymentSpec) { d.EnforceParameterSchema = boolPtr(!r.EnforceParameterSchema) },
+		"concurrency limit":        func(_ *Deployment, d *DeploymentSpec) { d.ConcurrencyLimit = intPtr(5) },
+		"concurrency limit unset remotely": func(r *Deployment, _ *DeploymentSpec) {
+			r.GlobalConcurrencyLimit = nil
+			r.ConcurrencyLimit = nil
+		},
+		"tags":       func(_ *Deployment, d *DeploymentSpec) { d.Tags = []string{"adsb", "jam"} },
+		"parameters": func(_ *Deployment, d *DeploymentSpec) { d.Parameters = map[string]any{"lookback": float64(6)} },
+		"job variables": func(_ *Deployment, d *DeploymentSpec) {
+			d.JobVariables = map[string]any{"env": map[string]any{"FOO": "baz"}}
+		},
+		"parameter openapi schema": func(_ *Deployment, d *DeploymentSpec) {
+			d.ParameterOpenAPISchema = map[string]any{"type": "object"}
+		},
+		"pull steps": func(_ *Deployment, d *DeploymentSpec) {
+			d.PullSteps = []map[string]any{{"prefect.deployments.steps.git_clone": map[string]any{}}}
+		},
+	}
+	for name, mutate := range mutations {
+		t.Run("changed "+name+" needs update", func(t *testing.T) {
+			remote, desired := matchingRemoteAndDesired()
+			mutate(remote, desired)
+			if DeploymentUpToDate(remote, desired) {
+				t.Fatal("expected update needed")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The Prefect server deletes **all of a deployment's future auto-scheduled runs on every deployment update**, even one that changes nothing — `models.deployments.update_deployment` calls `_delete_scheduled_runs(auto_scheduled_only=True, future_only=True)` unconditionally. The operator's periodic drift resync therefore resets each deployment's scheduling horizon on every cycle. The scheduler repopulates within seconds, but if the wipe lands close to a cron fire time, that run can be skipped entirely.

We hit this in production-like conditions with a `* * * * *` cron deployment: a resync near a minute boundary occasionally dropped a minute. #302/#305 already made *schedule* reconciliation diff-based; this PR does the same for the deployment object itself.

## Change

Before updating an existing deployment, the controller GETs the remote deployment and compares every operator-managed field of the desired spec against it (`DeploymentUpToDate`). When they match, the update call is skipped and the fetched deployment is used for status updates — a steady-state resync now performs zero mutating calls, so scheduled runs accumulate to the full horizon and stay put. The skip is logged at INFO so the surrounding `Starting sync` / `Successfully synced` pair doesn't read as if an update was written.

Comparison semantics (kept out of code comments deliberately, collected here):

- **Desired-driven**, mirroring the schedule diffing: a field the spec omits is not sent in the PATCH (`omitempty` client-side, `exclude_unset` server-side), so it cannot change the remote value and is ignored by the comparison.
- **Maps compare with `reflect.DeepEqual`**: both sides come from `encoding/json` unmarshalling (numbers are `float64` on both sides), so parameters / job variables / schema / pull steps compare cleanly.
- **Tags compare order-insensitively** — order isn't meaningful and must not force updates.
- **Schedules are not compared** — they're already managed separately and diffed in place by the controller (#302/#305).
- On GET failure or mismatch the behavior is exactly as before (update, falling back to create on 404).

### Why a `global_concurrency_limit` field is added to the `Deployment` response struct

The comparison must include the deployment's concurrency limit (it's an operator-managed field — a drifted limit has to trigger an update). But the server's `DeploymentResponse` returns the top-level `concurrency_limit` field as **always null** — it's deprecated, with the schema stating *"Will always be None for backwards compatibility"* — and exposes the live value only under `global_concurrency_limit.limit`. Without reading that object, the client cannot see the remote limit at all, so any deployment that sets `spec.deployment.concurrencyLimit` would never compare equal and would be PATCHed on every resync — wiping its scheduled runs and silently defeating this whole fix for exactly those deployments. Hence the one new (response-only) field; `DeploymentSpec` (the request payload) is unchanged. `concurrencyLimitMatches` still falls back to the top-level field for servers/mocks that populate it.

## Testing

- New table-driven unit tests for `DeploymentUpToDate` covering the skip case, desired-omitted fields, the deprecated concurrency-limit field, and a mutation matrix across all compared fields.
- Full `internal/...` suite passes (147 controller specs via envtest).
- Verified against a live Prefect 3.6.28 server: with this change, steady-state resyncs of 7 real deployments (including one with a concurrency limit) make zero mutating calls — deployment `updated` timestamps and scheduled-run `created` timestamps stay frozen across cycles, where previously every cycle re-created all scheduled runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)