### PR TITLE
fix: add missing prefectautomations rules to operator ClusterRole

### DIFF
--- a/deploy/charts/prefect-operator/templates/rbac.yaml
+++ b/deploy/charts/prefect-operator/templates/rbac.yaml
@@ -122,6 +122,26 @@ rules:
     verbs:
       - update
   - apiGroups: ["prefect.io"]
+    resources: ["prefectautomations"]
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups: ["prefect.io"]
+    resources: ["prefectautomations/status"]
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups: ["prefect.io"]
+    resources: ["prefectautomations/finalizers"]
+    verbs:
+      - update
+  - apiGroups: ["prefect.io"]
     resources: ["prefectworkqueues"]
     verbs:
       - get


### PR DESCRIPTION
## Summary

`PrefectAutomation` was added in [#294](<https://github.com/PrefectHQ/prefect-operator/issues/294>) with the usual controller RBAC markers:

```go
//+kubebuilder:rbac:groups=prefect.io,resources=prefectautomations,verbs=get;list;watch;create;update;patch;delete
//+kubebuilder:rbac:groups=prefect.io,resources=prefectautomations/status,verbs=get;update;patch
//+kubebuilder:rbac:groups=prefect.io,resources=prefectautomations/finalizers,verbs=update
```

…but the chart's `prefect-operator` ClusterRole in `deploy/charts/prefect-operator/templates/rbac.yaml` never got matching rules. That file is hand-maintained — `make manifests` only generates `crd webhook`, not RBAC — so the markers and the chart can drift silently. `PrefectWorkQueue` ([#311](<https://github.com/PrefectHQ/prefect-operator/issues/311>)) did add its rules; `PrefectAutomation` was missed.

The result is that the operator can't `list`/`watch` `PrefectAutomation`, the automation informer never syncs, and `mgr.Start` returns an error, so **the pod crash-loops even for users who own no** `PrefectAutomation` **resources**:

```
failed to list *v1.PrefectAutomation: prefectautomations.prefect.io is forbidden:
User "system:serviceaccount:<ns>:prefect-operator" cannot list resource
"prefectautomations" in API group "prefect.io" at the cluster scope
...
ERROR setup problem running manager {"error": "failed to wait for prefectdeployment
caches to sync kind source: *v1.PrefectDeployment: timed out waiting for cache to be synced..."}
```

This adds the three missing rules, matching the verb ordering and placement style of the neighbouring `prefectdeployments` / `prefectworkqueues` blocks.

Fixes PrefectHQ/prefect-operator#315

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)