### PR TITLE
Compare set-typed trigger fields order-insensitively in AutomationUpToDate

### DIFF
--- a/internal/prefect/automation_diff.go
+++ b/internal/prefect/automation_diff.go
@@ -3,6 +3,7 @@ package prefect
 import (
 	"encoding/json"
 	"reflect"
+	"sort"
 )
 
 // AutomationUpToDate reports whether the remote automation already matches
@@ -41,9 +42,14 @@ func actionsMatch(desired, remote []map[string]any) bool {
 	return true
 }
 
+// setKeys are trigger fields the server models as sets: it stores and returns
+// their elements in arbitrary order, so element order must not count as drift.
+var setKeys = map[string]bool{keyExpect: true, keyAfter: true, keyForEach: true}
+
 // subsetMatches reports whether every field present in desired equals its
 // remote counterpart; remote-only keys don't count as drift. Maps recurse per
-// key and slices compare elementwise.
+// key and slices compare elementwise, except set-typed trigger fields which
+// compare as multisets.
 func subsetMatches(desired, remote any) bool {
 	switch d := desired.(type) {
 	case map[string]any:
@@ -52,6 +58,12 @@ func subsetMatches(desired, remote any) bool {
 			return false
 		}
 		for k, dv := range d {
+			if setKeys[k] {
+				if !unorderedMatches(dv, r[k]) {
+					return false
+				}
+				continue
+			}
 			if !subsetMatches(dv, r[k]) {
 				return false
 			}
@@ -71,6 +83,40 @@ func subsetMatches(desired, remote any) bool {
 	default:
 		return reflect.DeepEqual(desired, remote)
 	}
+}
+
+// unorderedMatches compares two slices as multisets of their JSON encodings;
+// non-slice values fall back to ordered matching.
+func unorderedMatches(desired, remote any) bool {
+	d, dok := desired.([]any)
+	r, rok := remote.([]any)
+	if !dok || !rok {
+		return subsetMatches(desired, remote)
+	}
+	if len(d) != len(r) {
+		return false
+	}
+	dk, rk := jsonSorted(d), jsonSorted(r)
+	for i := range dk {
+		if dk[i] != rk[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func jsonSorted(items []any) []string {
+	keys := make([]string, 0, len(items))
+	for _, it := range items {
+		b, err := json.Marshal(it)
+		if err != nil {
+			keys = append(keys, "")
+			continue
+		}
+		keys = append(keys, string(b))
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // normalizeJSON round-trips a value through JSON so Go-typed desired values

--- a/internal/prefect/automation_diff.go
+++ b/internal/prefect/automation_diff.go
@@ -20,7 +20,7 @@ func AutomationUpToDate(remote *Automation, desired *AutomationSpec) bool {
 	if desired.Enabled != nil && *desired.Enabled != remote.Enabled {
 		return false
 	}
-	if !subsetMatches(normalizeJSON(desired.Trigger), normalizeJSON(remote.Trigger)) {
+	if !triggerMatches(normalizeJSON(desired.Trigger), normalizeJSON(remote.Trigger)) {
 		return false
 	}
 	return actionsMatch(desired.Actions, remote.Actions) &&
@@ -42,14 +42,57 @@ func actionsMatch(desired, remote []map[string]any) bool {
 	return true
 }
 
-// setKeys are trigger fields the server models as sets: it stores and returns
-// their elements in arbitrary order, so element order must not count as drift.
-var setKeys = map[string]bool{keyExpect: true, keyAfter: true, keyForEach: true}
+// unorderedTriggerKeys are event-trigger fields that the server stores as sets.
+var unorderedTriggerKeys = map[string]bool{keyExpect: true, keyAfter: true, keyForEach: true}
+
+// triggerMatches compares a trigger and recurses into its child triggers.
+// Event-trigger set fields compare as multisets.
+func triggerMatches(desired, remote any) bool {
+	d, ok := desired.(map[string]any)
+	if !ok {
+		return subsetMatches(desired, remote)
+	}
+	r, ok := remote.(map[string]any)
+	if !ok {
+		return false
+	}
+	isEventTrigger := d[keyType] == triggerTypeEvent
+	for k, dv := range d {
+		switch {
+		case isEventTrigger && unorderedTriggerKeys[k]:
+			if !unorderedMatches(dv, r[k]) {
+				return false
+			}
+		case k == keyTriggers:
+			if !triggerListMatches(dv, r[k]) {
+				return false
+			}
+		default:
+			if !subsetMatches(dv, r[k]) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func triggerListMatches(desired, remote any) bool {
+	d, dok := desired.([]any)
+	r, rok := remote.([]any)
+	if !dok || !rok || len(d) != len(r) {
+		return false
+	}
+	for i := range d {
+		if !triggerMatches(d[i], r[i]) {
+			return false
+		}
+	}
+	return true
+}
 
 // subsetMatches reports whether every field present in desired equals its
-// remote counterpart; remote-only keys don't count as drift. Maps recurse per
-// key and slices compare elementwise, except set-typed trigger fields which
-// compare as multisets.
+// remote counterpart. Remote-only keys do not count as drift. Maps recurse per
+// key, and slices compare elementwise.
 func subsetMatches(desired, remote any) bool {
 	switch d := desired.(type) {
 	case map[string]any:
@@ -58,12 +101,6 @@ func subsetMatches(desired, remote any) bool {
 			return false
 		}
 		for k, dv := range d {
-			if setKeys[k] {
-				if !unorderedMatches(dv, r[k]) {
-					return false
-				}
-				continue
-			}
 			if !subsetMatches(dv, r[k]) {
 				return false
 			}

--- a/internal/prefect/automation_diff_test.go
+++ b/internal/prefect/automation_diff_test.go
@@ -115,18 +115,35 @@ func TestAutomationUpToDate(t *testing.T) {
 	})
 
 	t.Run("matches when the server reorders set-typed trigger fields", func(t *testing.T) {
+		for _, field := range []string{keyAfter, keyExpect, keyForEach} {
+			t.Run(field, func(t *testing.T) {
+				spec := zombieSpec()
+				spec.Trigger[field] = []string{"first", "second", "third"}
+				remote := remoteFromSpec(t, spec)
+				remote.Trigger[field] = []any{"third", "first", "second"}
+				if !AutomationUpToDate(remote, spec) {
+					t.Fatalf("up to date = false for reordered %s; want true", field)
+				}
+			})
+		}
+	})
+
+	t.Run("matches when the server reorders a child event trigger set", func(t *testing.T) {
 		spec := zombieSpec()
-		spec.Trigger["expect"] = []string{
-			"prefect.flow-run.Pending", "prefect.flow-run.Running", "prefect.flow-run.Completed",
+		spec.Trigger = map[string]any{
+			keyType:   "compound",
+			"require": "all",
+			keyTriggers: []map[string]any{{
+				keyType:   "event",
+				keyExpect: []string{"first", "second"},
+			}},
 		}
 		remote := remoteFromSpec(t, spec)
-		// The server stores expect/after/for_each as sets and returns them in
-		// arbitrary order (verified live on Prefect 3.6.28).
-		remote.Trigger["expect"] = []any{
-			"prefect.flow-run.Completed", "prefect.flow-run.Pending", "prefect.flow-run.Running",
-		}
+		children := remote.Trigger[keyTriggers].([]any)
+		child := children[0].(map[string]any)
+		child[keyExpect] = []any{"second", "first"}
 		if !AutomationUpToDate(remote, spec) {
-			t.Fatal("up to date = false for a reordered expect set; want true")
+			t.Fatal("up to date = false for a reordered child event trigger set; want true")
 		}
 	})
 
@@ -137,6 +154,19 @@ func TestAutomationUpToDate(t *testing.T) {
 		remote.Trigger["expect"] = []any{"prefect.flow-run.Pending", "prefect.flow-run.Crashed"}
 		if AutomationUpToDate(remote, spec) {
 			t.Fatal("up to date = true with different expect content; want false")
+		}
+	})
+
+	t.Run("detects reordered slices in action parameters", func(t *testing.T) {
+		spec := zombieSpec()
+		spec.Actions[0]["parameters"] = map[string]any{
+			keyExpect: []string{"first", "second"},
+		}
+		remote := remoteFromSpec(t, spec)
+		parameters := remote.Actions[0]["parameters"].(map[string]any)
+		parameters[keyExpect] = []any{"second", "first"}
+		if AutomationUpToDate(remote, spec) {
+			t.Fatal("up to date = true for reordered action parameters; want false")
 		}
 	})
 

--- a/internal/prefect/automation_diff_test.go
+++ b/internal/prefect/automation_diff_test.go
@@ -114,6 +114,32 @@ func TestAutomationUpToDate(t *testing.T) {
 		}
 	})
 
+	t.Run("matches when the server reorders set-typed trigger fields", func(t *testing.T) {
+		spec := zombieSpec()
+		spec.Trigger["expect"] = []string{
+			"prefect.flow-run.Pending", "prefect.flow-run.Running", "prefect.flow-run.Completed",
+		}
+		remote := remoteFromSpec(t, spec)
+		// The server stores expect/after/for_each as sets and returns them in
+		// arbitrary order (verified live on Prefect 3.6.28).
+		remote.Trigger["expect"] = []any{
+			"prefect.flow-run.Completed", "prefect.flow-run.Pending", "prefect.flow-run.Running",
+		}
+		if !AutomationUpToDate(remote, spec) {
+			t.Fatal("up to date = false for a reordered expect set; want true")
+		}
+	})
+
+	t.Run("detects a set-typed trigger field content change", func(t *testing.T) {
+		spec := zombieSpec()
+		spec.Trigger["expect"] = []string{"prefect.flow-run.Pending", "prefect.flow-run.Running"}
+		remote := remoteFromSpec(t, spec)
+		remote.Trigger["expect"] = []any{"prefect.flow-run.Pending", "prefect.flow-run.Crashed"}
+		if AutomationUpToDate(remote, spec) {
+			t.Fatal("up to date = true with different expect content; want false")
+		}
+	})
+
 	t.Run("nil desired action lists match empty remote lists", func(t *testing.T) {
 		spec := zombieSpec()
 		remote := remoteFromSpec(t, spec)

--- a/internal/prefect/convert_automation.go
+++ b/internal/prefect/convert_automation.go
@@ -36,6 +36,11 @@ const (
 	keyMatch        = "match"
 	keyMatchRelated = "match_related"
 	keyTriggers     = "triggers"
+	// keyAfter/keyExpect/keyForEach are the set-typed event-trigger keys: the
+	// server stores them as sets, so the diff layer compares them unordered.
+	keyAfter   = "after"
+	keyExpect  = "expect"
+	keyForEach = "for_each"
 	// keyMetric is the metric-trigger payload key (same spelling as the type
 	// discriminator value, different role).
 	keyMetric = "metric"
@@ -141,9 +146,9 @@ func buildEventTrigger(e *prefectiov1.PrefectEventTrigger) (map[string]any, erro
 		"posture":       e.Posture,
 		keyMatch:        match,
 		keyMatchRelated: matchRelated,
-		"after":         nonNilStrings(e.After),
-		"expect":        nonNilStrings(e.Expect),
-		"for_each":      nonNilStrings(e.ForEach),
+		keyAfter:        nonNilStrings(e.After),
+		keyExpect:       nonNilStrings(e.Expect),
+		keyForEach:      nonNilStrings(e.ForEach),
 	}
 	if e.Threshold != nil {
 		m["threshold"] = *e.Threshold


### PR DESCRIPTION
## Problem

#316 added the no-op update skip so resyncs don't PUT unchanged automations (every PUT rotates the trigger's server-assigned ID, discarding its proactive bucket state). The skip works for single-element `expect` lists, but the server models `expect`/`after`/`for_each` as **sets** and returns their elements in arbitrary order. `subsetMatches` compares slices elementwise, so any automation with a multi-element `expect` list reports drift on every resync → PUT → trigger-ID rotation → orphaned proactive buckets.

Net effect, verified live on a Prefect 3.6.28 server: a Proactive automation with a 7-element `expect` list logged `Updating automation` on every ~5min resync (4 PUTs in 30 minutes) and **never fired** — an armed bucket was orphaned before its `within` window elapsed, every time. The same automation with a single-element `expect` logged `already up to date, skipping update` and fired exactly on schedule.

## Fix

`expect`, `after`, and `for_each` compare as multisets (sorted JSON encodings); all other slices keep ordered comparison — e.g. arrays inside action `parameters` are user data where a reorder is a real change that must trigger an update.

## Tests

- `matches when the server reorders set-typed trigger fields` — reordered `expect` is not drift
- `detects a set-typed trigger field content change` — same-length different-content still updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
